### PR TITLE
Bug fix for debug output and queueFlags

### DIFF
--- a/PROFILES.md
+++ b/PROFILES.md
@@ -483,7 +483,7 @@
 | **Queue family #0** |
 | minImageTransferGranularity (min) |  |  | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">(1,1,1)</span> | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">(1,1,1)</span> |
 | queueCount (max) |  |  | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">1</span> | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">1</span> |
-| queueFlags |  |  | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">(VK_QUEUE_GRAPHICS_BIT \| VK_QUEUE_COMPUTE_BIT \| VK_QUEUE_TRANSFER_BIT \| VK_QUEUE_SPARSE_BINDING_BIT)</span> | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">(VK_QUEUE_GRAPHICS_BIT \| VK_QUEUE_COMPUTE_BIT \| VK_QUEUE_TRANSFER_BIT \| VK_QUEUE_SPARSE_BINDING_BIT)</span> |
+| queueFlags (min) |  |  | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">(VK_QUEUE_GRAPHICS_BIT \| VK_QUEUE_COMPUTE_BIT \| VK_QUEUE_TRANSFER_BIT \| VK_QUEUE_SPARSE_BINDING_BIT)</span> | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">(VK_QUEUE_GRAPHICS_BIT \| VK_QUEUE_COMPUTE_BIT \| VK_QUEUE_TRANSFER_BIT \| VK_QUEUE_SPARSE_BINDING_BIT)</span> |
 | timestampValidBits (max) |  |  | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">36</span> | <span title="defined in VkQueueFamilyProperties (Vulkan 1.0)">36</span> |
 
 ## Vulkan Profile Formats

--- a/library/include/vulkan/debug/vulkan_profiles.hpp
+++ b/library/include/vulkan/debug/vulkan_profiles.hpp
@@ -252,7 +252,7 @@ VPAPI_ATTR VkResult vpGetProfileFormatStructureTypes(const VpProfileProperties *
 #include <stdio.h>
 
 #ifndef VP_DEBUG_MESSAGE_CALLBACK
-#define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, MSG)
+#define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, "%s\n", MSG)
 #else
 void VP_DEBUG_MESSAGE_CALLBACK(const char*);
 #endif

--- a/library/include/vulkan/debug/vulkan_profiles.hpp
+++ b/library/include/vulkan/debug/vulkan_profiles.hpp
@@ -3851,7 +3851,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;
@@ -6164,7 +6164,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;

--- a/library/include/vulkan/vulkan_profiles.hpp
+++ b/library/include/vulkan/vulkan_profiles.hpp
@@ -3838,7 +3838,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;
@@ -6151,7 +6151,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;

--- a/library/scripts/genvp.py
+++ b/library/scripts/genvp.py
@@ -1757,6 +1757,7 @@ class VulkanRegistry():
         self.structs['VkFormatProperties3'].members['linearTilingFeatures'].limittype = 'bitmask'
         self.structs['VkFormatProperties3'].members['optimalTilingFeatures'].limittype = 'bitmask'
         self.structs['VkFormatProperties3'].members['bufferFeatures'].limittype = 'bitmask'
+        self.structs['VkQueueFamilyProperties'].members['queueFlags'].limittype = 'bitmask'
         self.structs['VkQueueFamilyProperties'].members['queueCount'].limittype = 'max'
         self.structs['VkQueueFamilyProperties'].members['timestampValidBits'].limittype = 'max'
         self.structs['VkQueueFamilyProperties'].members['minImageTransferGranularity'].limittype = 'min' # should be maxmul

--- a/library/scripts/genvp.py
+++ b/library/scripts/genvp.py
@@ -49,7 +49,7 @@ DEBUG_MSG_CB_DEFINE = '''
 #include <stdio.h>
 
 #ifndef VP_DEBUG_MESSAGE_CALLBACK
-#define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, MSG)
+#define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, "%s\\n", MSG)
 #else
 void VP_DEBUG_MESSAGE_CALLBACK(const char*);
 #endif

--- a/library/source/debug/vulkan_profiles.cpp
+++ b/library/source/debug/vulkan_profiles.cpp
@@ -3625,7 +3625,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;
@@ -5938,7 +5938,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;

--- a/library/source/debug/vulkan_profiles.cpp
+++ b/library/source/debug/vulkan_profiles.cpp
@@ -26,7 +26,7 @@
 #include <stdio.h>
 
 #ifndef VP_DEBUG_MESSAGE_CALLBACK
-#define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, MSG)
+#define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, "%s\n", MSG)
 #else
 void VP_DEBUG_MESSAGE_CALLBACK(const char*);
 #endif

--- a/library/source/vulkan_profiles.cpp
+++ b/library/source/vulkan_profiles.cpp
@@ -3612,7 +3612,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;
@@ -5925,7 +5925,7 @@ static const VpQueueFamilyDesc queueFamilyDesc[] = {
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.height <= 1);
                     ret = ret && (s->queueFamilyProperties.minImageTransferGranularity.width <= 1);
                     ret = ret && (s->queueFamilyProperties.queueCount >= 1);
-                    ret = ret && (s->queueFamilyProperties.queueFlags == (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT));
+                    ret = ret && (vpCheckFlags(s->queueFamilyProperties.queueFlags, (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)));
                     ret = ret && (s->queueFamilyProperties.timestampValidBits >= 36);
                 } break;
                 default: break;


### PR DESCRIPTION
This PR fixes the following issues:
- Missing new line in the debug output when using the debug version of the library with the default (`stderr`) callback value
- Add workaround for missing `limittype` attribute for `VkQueueFamilyProperties::queueFlags`