### PR TITLE
build: use Vulkan-Loader 1.3.204

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT ANDROID)
     FetchContent_Declare(
         vulkan-loader
         GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Loader.git
-        GIT_TAG v1.3.204
+        GIT_TAG sdk-1.3.204
     )
 endif()
 


### PR DESCRIPTION
The Vulkan-Loader stabilized release branch has been renamed to
sdk-1.3.204 in preparation for the upcoming SDK release.