### PR TITLE
profiles layer: Fix extensions in test profile

### DIFF
--- a/layer/tests/tests.cpp
+++ b/layer/tests/tests.cpp
@@ -164,7 +164,7 @@ TEST(layer, TestSetCombinationMode) {
             std::vector<VkExtensionProperties> extensions(count);
             vkEnumerateDeviceExtensionProperties(gpu, nullptr, &count, extensions.data());
 
-            ASSERT_EQ(extensions.size(), 234);
+            ASSERT_GE(extensions.size(), 234);
         }
 
         vkDestroyInstance(test_inst, nullptr);

--- a/profiles/test/data/VP_LUNARG_test_api.json
+++ b/profiles/test/data/VP_LUNARG_test_api.json
@@ -235,9 +235,8 @@
                 "VK_QCOM_rotated_copy_commands": 1,
                 "VK_VALVE_mutable_descriptor_type": 1,
                 "VK_QCOM_fragment_density_map_offset": 1,
-                "VK_EXT_depth_clip_control": 1,
-                "VK_ARM_rasterization_order_attachment_access": 1,
                 "VK_NV_linear_color_attachment": 1,
+                "VK_KHR_global_priority": 1,
                 "VK_KHR_external_memory_capabilities": 1
             },
             "features": {


### PR DESCRIPTION
Some extensions were duplicated, `VK_KHR_global_priority` was missing.