### PR TITLE
Add header file for layer source

### DIFF
--- a/layer/profiles.cpp
+++ b/layer/profiles.cpp
@@ -66,6 +66,7 @@
 #include <vk_layer_config.h>
 #include "vk_layer_table.h"
 #include "vk_layer_settings.h"
+#include "profiles.h"
 
 using valijson::Schema;
 using valijson::SchemaParser;
@@ -131,15 +132,6 @@ const char *const kLayerSettingsDebugFilename = "debug_filename";
 const char *const kLayerSettingsDebugFileClear = "debug_file_clear";
 const char *const kLayerSettingsDebugFailOnError = "debug_fail_on_error";
 const char *const kLayerSettingsDebugReports = "debug_reports";
-
-enum SimulateCapabilityFlag {
-    SIMULATE_API_VERSION_BIT = 1 << 0,
-    SIMULATE_FEATURES_BIT = 1 << 1,
-    SIMULATE_PROPERTIES_BIT = 1 << 2,
-    SIMULATE_EXTENSIONS_BIT = 1 << 3,
-    SIMULATE_FORMATS_BIT = 1 << 4
-};
-typedef int SimulateCapabilityFlags;
 
 static SimulateCapabilityFlags GetSimulateCapabilityFlags(const vku::Strings &values) {
     SimulateCapabilityFlags result = 0;

--- a/layer/profiles.h
+++ b/layer/profiles.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015-2022 Valve Corporation
+ * Copyright (C) 2015-2022 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ */
+
+enum SimulateCapabilityFlag {
+    SIMULATE_API_VERSION_BIT = 1 << 0,
+    SIMULATE_FEATURES_BIT = 1 << 1,
+    SIMULATE_PROPERTIES_BIT = 1 << 2,
+    SIMULATE_EXTENSIONS_BIT = 1 << 3,
+    SIMULATE_FORMATS_BIT = 1 << 4,
+    SIMULATE_FORMAT_PROPERTIES_BIT = 1 << 5
+};
+typedef int SimulateCapabilityFlags;

--- a/layer/tests/profiles_test_helper.h
+++ b/layer/tests/profiles_test_helper.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <vulkan/vulkan.h>
+#include "../profiles.h"
 
 namespace profiles_test {
 
@@ -29,16 +30,6 @@ void setEnvironmentSetting(std::string setting, const char* val);
 void unsetEnvironmentSetting(std::string setting);
 
 std::string getAbsolutePath(std::string filepath);
-
-enum SimulateCapabilityFlag {
-    SIMULATE_API_VERSION_BIT = 1 << 0,
-    SIMULATE_FEATURES_BIT = 1 << 1,
-    SIMULATE_PROPERTIES_BIT = 1 << 2,
-    SIMULATE_EXTENSIONS_BIT = 1 << 3,
-    SIMULATE_FORMATS_BIT = 1 << 4,
-    SIMULATE_FORMAT_PROPERTIES_BIT = 1 << 5
-};
-typedef int SimulateCapabilityFlags;
 
 void setProfilesFilename(const std::string& filepath);
 void setProfilesDebugEnable(bool enable);

--- a/layer/tests/tests.cpp
+++ b/layer/tests/tests.cpp
@@ -94,7 +94,7 @@ TEST(layer, TestSetCombinationMode) {
         profiles_test::setProfilesFilename(filepath);
         profiles_test::setProfilesEmulatePortabilitySubsetExtension(true);
         profiles_test::setProfilesProfileName("VP_LUNARG_test_api_1_2_198");
-        profiles_test::setProfilesSimulateCapabilities(profiles_test::SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT);
+        profiles_test::setProfilesSimulateCapabilities(SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT);
         profiles_test::setProfilesFailOnError(false);
 
         err = inst_builder.makeInstance();
@@ -139,7 +139,7 @@ TEST(layer, TestSetCombinationMode) {
         profiles_test::setProfilesFilename(filepath);
         profiles_test::setProfilesEmulatePortabilitySubsetExtension(true);
         profiles_test::setProfilesProfileName("VP_LUNARG_test_api");
-        profiles_test::setProfilesSimulateCapabilities(profiles_test::SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT);
+        profiles_test::setProfilesSimulateCapabilities(SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT);
         profiles_test::setProfilesFailOnError(false);
 
         err = inst_builder.makeInstance();
@@ -206,7 +206,7 @@ TEST(layer, TestExtensionNotSupported) {
         profiles_test::setProfilesFilename(filepath);
         profiles_test::setProfilesEmulatePortabilitySubsetExtension(true);
         profiles_test::setProfilesProfileName("VP_LUNARG_test_api");
-        profiles_test::setProfilesSimulateCapabilities(profiles_test::SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT);
+        profiles_test::setProfilesSimulateCapabilities(SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT);
         profiles_test::setProfilesFailOnError(true);
 
         err = inst_builder.makeInstance();

--- a/layer/tests/tests_mechanism.cpp
+++ b/layer/tests/tests_mechanism.cpp
@@ -26,8 +26,8 @@ TEST(layer, selecting_profile) {
         profiles_test::setProfilesFilename(filepath);
         profiles_test::setProfilesProfileName("VP_LUNARG_test_selecting_profile");
         profiles_test::setProfilesEmulatePortabilitySubsetExtension(true);
-        profiles_test::setProfilesSimulateCapabilities(profiles_test::SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT |
-                                                       profiles_test::SimulateCapabilityFlag::SIMULATE_PROPERTIES_BIT);
+        profiles_test::setProfilesSimulateCapabilities(SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT |
+                                                       SimulateCapabilityFlag::SIMULATE_PROPERTIES_BIT);
 
         inst_builder.addLayer("VK_LAYER_KHRONOS_profiles");
 
@@ -57,8 +57,8 @@ TEST(layer, selecting_profile) {
         profiles_test::setProfilesFilename(filepath);
         profiles_test::setProfilesProfileName("VP_LUNARG_test_selecting_profile_subset");
         profiles_test::setProfilesEmulatePortabilitySubsetExtension(true);
-        profiles_test::setProfilesSimulateCapabilities(profiles_test::SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT |
-                                                       profiles_test::SimulateCapabilityFlag::SIMULATE_PROPERTIES_BIT);
+        profiles_test::setProfilesSimulateCapabilities(SimulateCapabilityFlag::SIMULATE_EXTENSIONS_BIT |
+                                                       SimulateCapabilityFlag::SIMULATE_PROPERTIES_BIT);
 
         inst_builder.addLayer("VK_LAYER_KHRONOS_profiles");
 


### PR DESCRIPTION
Allows data to be shared between the layer and the layer tests without creating copies.  Happy to namespace things differently or reorganize things and folks see fit.