### PR TITLE
layer: fix missing macos preset entry

### DIFF
--- a/layer/VkLayer_khronos_profiles.json.in
+++ b/layer/VkLayer_khronos_profiles.json.in
@@ -22,9 +22,9 @@
         "features": {
             "presets": [
                 {
-                    "label": "LunarG Desktop Portability Profile",
+                    "label": "LunarG Desktop Portability",
                     "description": "Check the Vulkan 1.1 application will run on Windows,  Linux and macOS platforms without exceeding ecosystem effective devices capabilities",
-                    "platforms": [ "WINDOWS", "LINUX" ],
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
                     "status": "STABLE",
                     "settings": [
                         {
@@ -46,9 +46,9 @@
                     ]
                 },
                 {
-                    "label": "Khronos Roadmap 2022 Profile",
+                    "label": "Khronos Roadmap 2022",
                     "description": "Check the Vulkan 1.3 application will run on the Khronos Roadmap 2022 Profile devices",
-                    "platforms": [ "WINDOWS", "LINUX" ],
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
                     "status": "STABLE",
                     "settings": [
                         {
@@ -70,9 +70,9 @@
                     ]
                 },
                 {
-                    "label": "Android Baseline 2021 Profile",
+                    "label": "Android Baseline 2021",
                     "description": "Check the Vulkan 1.0 application will run on the Android Baseline 2022 Profile devices",
-                    "platforms": [ "WINDOWS", "LINUX" ],
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
                     "status": "STABLE",
                     "settings": [
                         {


### PR DESCRIPTION
This caused a crash when selecting the portability layers configuration in Vulkan Configurator