### PR TITLE
profiles layer: Add GetPhysDev2 extensions of not present

### DIFF
--- a/layer/TUTORIAL.md
+++ b/layer/TUTORIAL.md
@@ -30,6 +30,8 @@ The *Portability* layers configuration in *Vulkan Configurator* allows checking 
 
 The input to the *Profiles layer* is a profiles file that is using the flexible JSON syntax. The profiles file format is defined by a formal JSON schema, so any profiles file may be verified to be correct using freely available JSON validators. Browsing through the schema file, we can see the extent of parameters that are available for our configuration.
 
+To use the Profiles Layer Vulkan version 1.0 and the `VK_KHR_get_physical_device_properties2` extension are required.
+
 Example of a *Profiles layer* JSON profiles file: [VP_LUNARG_test_structure_simple.json](https://github.com/KhronosGroup/Vulkan-Profiles/blob/master/profiles/test/data/VP_LUNARG_test_structure_simple.json)
 
 ### Android

--- a/layer/tests/tests.cpp
+++ b/layer/tests/tests.cpp
@@ -333,3 +333,31 @@ TEST(layer, TestExcludingFormats) {
     ASSERT_EQ(format_properties.optimalTilingFeatures, 0);
     ASSERT_EQ(format_properties.bufferFeatures, 0);
 }
+
+
+TEST(layer, TestMissingPhysDevProps2) {
+    VkResult err = VK_SUCCESS;
+
+    const std::string layer_path = std::string(TEST_BINARY_PATH) + CONFIG_PATH;
+    profiles_test::setEnvironmentSetting("VK_LAYER_PATH", layer_path.c_str());
+
+    profiles_test::VulkanInstanceBuilder inst_builder;
+
+    const std::string filepath = TEST_SOURCE_PATH "/../../profiles/VP_LUNARG_desktop_portability_2021.json";
+    profiles_test::setProfilesFilename(filepath);
+    profiles_test::setProfilesProfileName("VP_LUNARG_desktop_portability_2021");
+    profiles_test::setProfilesEmulatePortabilitySubsetExtension(false);
+    profiles_test::setProfilesFailOnError(false);
+    profiles_test::setProfilesSimulateAllCapabilities();
+
+    inst_builder.addLayer("VK_LAYER_KHRONOS_profiles");
+    inst_builder.setApiVersion(VK_API_VERSION_1_0);
+    err = inst_builder.makeInstance();
+
+    VkPhysicalDevice gpu;
+    err = inst_builder.getPhysicalDevice(&gpu);
+
+    uint32_t count = 0;
+    vkEnumerateDeviceExtensionProperties(gpu, nullptr, &count, nullptr);
+    ASSERT_EQ(count, 19);
+}


### PR DESCRIPTION
The Profiles Layer requires the `VK_KHR_get_physical_device_properties2` extension, without it it's not functional. 