### PR TITLE
profiles layer: Fix filling format properties pNext chain

### DIFF
--- a/layer/profiles.cpp
+++ b/layer/profiles.cpp
@@ -8499,10 +8499,12 @@ void FillFormatPropertiesPNextChain(PhysicalDeviceData *physicalDeviceData, void
 
         switch (structure->sType) {
             case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3: {
-                VkFormatProperties3 *sp = (VkFormatProperties3 *)place;
-                void *pNext = sp->pNext;
-                *sp = physicalDeviceData->arrayof_format_properties_3_[format];
-                sp->pNext = pNext;
+                if (!physicalDeviceData->arrayof_format_properties_3_.empty()) {
+                    VkFormatProperties3 *sp = (VkFormatProperties3 *)place;
+                    void *pNext = sp->pNext;
+                    *sp = physicalDeviceData->arrayof_format_properties_3_[format];
+                    sp->pNext = pNext;
+                }
             } break;
             default:
                 break;


### PR DESCRIPTION
The pNext chain in VkFormatProperties2KHR must only be filled if any `VkFormatProperties3` were loaded. 