### PR TITLE
Fix JSON schema profile name matching

### DIFF
--- a/schema/profile_schema.json
+++ b/schema/profile_schema.json
@@ -7033,6 +7033,7 @@
         "profiles": {
             "description": "The list of profile definitions.",
             "type": "object",
+            "additionalProperties": false,
             "patternProperties": {
                 "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
                     "type": "object",

--- a/scripts/genvp.py
+++ b/scripts/genvp.py
@@ -2699,6 +2699,7 @@ class VulkanProfilesSchemaGenerator():
                 "profiles": OrderedDict({
                     "description": "The list of profile definitions.",
                     "type": "object",
+                    "additionalProperties": False,
                     "patternProperties": OrderedDict({
                         "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": OrderedDict({
                             "type": "object",
@@ -3873,7 +3874,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if args.outIncDir is None and args.outSchema is None and args.outDoc is None:
+    if args.outIncDir is None and args.outSchema is None and args.outDoc is None and not args.validate:
         parser.print_help()
         exit()
 


### PR DESCRIPTION
Also allow invoking the generator script only for JSON validation
purposes (as a convenience feature during testing).