### PR TITLE
Fix and improve queue family matching in library

### DIFF
--- a/library/include/vulkan/debug/vulkan_profiles.hpp
+++ b/library/include/vulkan/debug/vulkan_profiles.hpp
@@ -8336,17 +8336,23 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
 
         detail::PFN_vpStructChainerCb callback = [](VkBaseOutStructure* p, void* pUser) {
             UserData* pUserData = static_cast<UserData*>(pUser);
+            VkQueueFamilyProperties2KHR* pProps = static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p));
             if (++pUserData->index < pUserData->count) {
-                pUserData->pDesc->chainers.pfnQueueFamily(++p, pUser, pUserData->pfnCb);
+                pUserData->pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(++pProps)),
+                                                          pUser, pUserData->pfnCb);
             } else {
-                p -= pUserData->count - 1;
+                pProps -= pUserData->count - 1;
                 pUserData->gpdp2.pfnGetPhysicalDeviceQueueFamilyProperties2(pUserData->physicalDevice,
                                                                             &pUserData->count,
-                                                                            static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p)));
+                                                                            pProps);
+                pUserData->supported = true;
+
+                // Check first that each queue family defined is supported by the device
                 for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount; ++i) {
                     bool found = false;
                     for (uint32_t j = 0; j < pUserData->count; ++j) {
                         bool propsMatch = true;
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[j]));
                         while (p != nullptr) {
                             if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
                                 propsMatch = false;
@@ -8362,14 +8368,51 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
                     if (!found) {
                         VP_DEBUG_MSGF("Unsupported queue family defined at profile data index #%u", i);
                         pUserData->supported = false;
+                        return;
                     }
+                }
+
+                // Then check each permutation to ensure that while order of the queue families
+                // doesn't matter, each queue family property criteria is matched with a separate
+                // queue family of the actual device
+                std::vector<uint32_t> permutation(pUserData->count);
+                for (uint32_t i = 0; i < pUserData->count; ++i) {
+                    permutation[i] = i;
+                }
+                bool found = false;
+                do {
+                    bool propsMatch = true;
+                    for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount && propsMatch; ++i) {
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[permutation[i]]));
+                        while (p != nullptr) {
+                            if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
+                                propsMatch = false;
+                                break;
+                            }
+                            p = p->pNext;
+                        }
+                    }
+                    if (propsMatch) {
+                        found = true;
+                        break;
+                    }
+                } while (std::next_permutation(permutation.begin(), permutation.end()));
+
+                if (!found) {
+                    VP_DEBUG_MSG("Unsupported combination of queue families");
+                    pUserData->supported = false;
                 }
             }
         };
         userData.pfnCb = callback;
 
-        pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
-        if (!userData.supported) {
+        if (userData.count >= userData.pDesc->queueFamilyCount) {
+            pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
+            if (!userData.supported) {
+                *pSupported = VK_FALSE;
+            }
+        } else {
+            VP_DEBUG_MSGF("Unsupported number of queue families: device has fewer (%u) than what the profile defines (%u)", userData.count, userData.pDesc->queueFamilyCount);
             *pSupported = VK_FALSE;
         }
     }

--- a/library/include/vulkan/vulkan_profiles.hpp
+++ b/library/include/vulkan/vulkan_profiles.hpp
@@ -8295,17 +8295,23 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
 
         detail::PFN_vpStructChainerCb callback = [](VkBaseOutStructure* p, void* pUser) {
             UserData* pUserData = static_cast<UserData*>(pUser);
+            VkQueueFamilyProperties2KHR* pProps = static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p));
             if (++pUserData->index < pUserData->count) {
-                pUserData->pDesc->chainers.pfnQueueFamily(++p, pUser, pUserData->pfnCb);
+                pUserData->pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(++pProps)),
+                                                          pUser, pUserData->pfnCb);
             } else {
-                p -= pUserData->count - 1;
+                pProps -= pUserData->count - 1;
                 pUserData->gpdp2.pfnGetPhysicalDeviceQueueFamilyProperties2(pUserData->physicalDevice,
                                                                             &pUserData->count,
-                                                                            static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p)));
+                                                                            pProps);
+                pUserData->supported = true;
+
+                // Check first that each queue family defined is supported by the device
                 for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount; ++i) {
                     bool found = false;
                     for (uint32_t j = 0; j < pUserData->count; ++j) {
                         bool propsMatch = true;
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[j]));
                         while (p != nullptr) {
                             if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
                                 propsMatch = false;
@@ -8320,14 +8326,49 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
                     }
                     if (!found) {
                         pUserData->supported = false;
+                        return;
                     }
+                }
+
+                // Then check each permutation to ensure that while order of the queue families
+                // doesn't matter, each queue family property criteria is matched with a separate
+                // queue family of the actual device
+                std::vector<uint32_t> permutation(pUserData->count);
+                for (uint32_t i = 0; i < pUserData->count; ++i) {
+                    permutation[i] = i;
+                }
+                bool found = false;
+                do {
+                    bool propsMatch = true;
+                    for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount && propsMatch; ++i) {
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[permutation[i]]));
+                        while (p != nullptr) {
+                            if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
+                                propsMatch = false;
+                                break;
+                            }
+                            p = p->pNext;
+                        }
+                    }
+                    if (propsMatch) {
+                        found = true;
+                        break;
+                    }
+                } while (std::next_permutation(permutation.begin(), permutation.end()));
+
+                if (!found) {
+                    pUserData->supported = false;
                 }
             }
         };
         userData.pfnCb = callback;
 
-        pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
-        if (!userData.supported) {
+        if (userData.count >= userData.pDesc->queueFamilyCount) {
+            pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
+            if (!userData.supported) {
+                *pSupported = VK_FALSE;
+            }
+        } else {
             *pSupported = VK_FALSE;
         }
     }

--- a/library/source/debug/vulkan_profiles.cpp
+++ b/library/source/debug/vulkan_profiles.cpp
@@ -8110,17 +8110,23 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
 
         detail::PFN_vpStructChainerCb callback = [](VkBaseOutStructure* p, void* pUser) {
             UserData* pUserData = static_cast<UserData*>(pUser);
+            VkQueueFamilyProperties2KHR* pProps = static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p));
             if (++pUserData->index < pUserData->count) {
-                pUserData->pDesc->chainers.pfnQueueFamily(++p, pUser, pUserData->pfnCb);
+                pUserData->pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(++pProps)),
+                                                          pUser, pUserData->pfnCb);
             } else {
-                p -= pUserData->count - 1;
+                pProps -= pUserData->count - 1;
                 pUserData->gpdp2.pfnGetPhysicalDeviceQueueFamilyProperties2(pUserData->physicalDevice,
                                                                             &pUserData->count,
-                                                                            static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p)));
+                                                                            pProps);
+                pUserData->supported = true;
+
+                // Check first that each queue family defined is supported by the device
                 for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount; ++i) {
                     bool found = false;
                     for (uint32_t j = 0; j < pUserData->count; ++j) {
                         bool propsMatch = true;
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[j]));
                         while (p != nullptr) {
                             if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
                                 propsMatch = false;
@@ -8136,14 +8142,51 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
                     if (!found) {
                         VP_DEBUG_MSGF("Unsupported queue family defined at profile data index #%u", i);
                         pUserData->supported = false;
+                        return;
                     }
+                }
+
+                // Then check each permutation to ensure that while order of the queue families
+                // doesn't matter, each queue family property criteria is matched with a separate
+                // queue family of the actual device
+                std::vector<uint32_t> permutation(pUserData->count);
+                for (uint32_t i = 0; i < pUserData->count; ++i) {
+                    permutation[i] = i;
+                }
+                bool found = false;
+                do {
+                    bool propsMatch = true;
+                    for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount && propsMatch; ++i) {
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[permutation[i]]));
+                        while (p != nullptr) {
+                            if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
+                                propsMatch = false;
+                                break;
+                            }
+                            p = p->pNext;
+                        }
+                    }
+                    if (propsMatch) {
+                        found = true;
+                        break;
+                    }
+                } while (std::next_permutation(permutation.begin(), permutation.end()));
+
+                if (!found) {
+                    VP_DEBUG_MSG("Unsupported combination of queue families");
+                    pUserData->supported = false;
                 }
             }
         };
         userData.pfnCb = callback;
 
-        pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
-        if (!userData.supported) {
+        if (userData.count >= userData.pDesc->queueFamilyCount) {
+            pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
+            if (!userData.supported) {
+                *pSupported = VK_FALSE;
+            }
+        } else {
+            VP_DEBUG_MSGF("Unsupported number of queue families: device has fewer (%u) than what the profile defines (%u)", userData.count, userData.pDesc->queueFamilyCount);
             *pSupported = VK_FALSE;
         }
     }

--- a/library/source/vulkan_profiles.cpp
+++ b/library/source/vulkan_profiles.cpp
@@ -8069,17 +8069,23 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
 
         detail::PFN_vpStructChainerCb callback = [](VkBaseOutStructure* p, void* pUser) {
             UserData* pUserData = static_cast<UserData*>(pUser);
+            VkQueueFamilyProperties2KHR* pProps = static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p));
             if (++pUserData->index < pUserData->count) {
-                pUserData->pDesc->chainers.pfnQueueFamily(++p, pUser, pUserData->pfnCb);
+                pUserData->pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(++pProps)),
+                                                          pUser, pUserData->pfnCb);
             } else {
-                p -= pUserData->count - 1;
+                pProps -= pUserData->count - 1;
                 pUserData->gpdp2.pfnGetPhysicalDeviceQueueFamilyProperties2(pUserData->physicalDevice,
                                                                             &pUserData->count,
-                                                                            static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p)));
+                                                                            pProps);
+                pUserData->supported = true;
+
+                // Check first that each queue family defined is supported by the device
                 for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount; ++i) {
                     bool found = false;
                     for (uint32_t j = 0; j < pUserData->count; ++j) {
                         bool propsMatch = true;
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[j]));
                         while (p != nullptr) {
                             if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
                                 propsMatch = false;
@@ -8094,14 +8100,49 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
                     }
                     if (!found) {
                         pUserData->supported = false;
+                        return;
                     }
+                }
+
+                // Then check each permutation to ensure that while order of the queue families
+                // doesn't matter, each queue family property criteria is matched with a separate
+                // queue family of the actual device
+                std::vector<uint32_t> permutation(pUserData->count);
+                for (uint32_t i = 0; i < pUserData->count; ++i) {
+                    permutation[i] = i;
+                }
+                bool found = false;
+                do {
+                    bool propsMatch = true;
+                    for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount && propsMatch; ++i) {
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[permutation[i]]));
+                        while (p != nullptr) {
+                            if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
+                                propsMatch = false;
+                                break;
+                            }
+                            p = p->pNext;
+                        }
+                    }
+                    if (propsMatch) {
+                        found = true;
+                        break;
+                    }
+                } while (std::next_permutation(permutation.begin(), permutation.end()));
+
+                if (!found) {
+                    pUserData->supported = false;
                 }
             }
         };
         userData.pfnCb = callback;
 
-        pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
-        if (!userData.supported) {
+        if (userData.count >= userData.pDesc->queueFamilyCount) {
+            pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
+            if (!userData.supported) {
+                *pSupported = VK_FALSE;
+            }
+        } else {
             *pSupported = VK_FALSE;
         }
     }

--- a/scripts/genvp.py
+++ b/scripts/genvp.py
@@ -742,17 +742,23 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
 
         detail::PFN_vpStructChainerCb callback = [](VkBaseOutStructure* p, void* pUser) {
             UserData* pUserData = static_cast<UserData*>(pUser);
+            VkQueueFamilyProperties2KHR* pProps = static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p));
             if (++pUserData->index < pUserData->count) {
-                pUserData->pDesc->chainers.pfnQueueFamily(++p, pUser, pUserData->pfnCb);
+                pUserData->pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(++pProps)),
+                                                          pUser, pUserData->pfnCb);
             } else {
-                p -= pUserData->count - 1;
+                pProps -= pUserData->count - 1;
                 pUserData->gpdp2.pfnGetPhysicalDeviceQueueFamilyProperties2(pUserData->physicalDevice,
                                                                             &pUserData->count,
-                                                                            static_cast<VkQueueFamilyProperties2KHR*>(static_cast<void*>(p)));
+                                                                            pProps);
+                pUserData->supported = true;
+
+                // Check first that each queue family defined is supported by the device
                 for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount; ++i) {
                     bool found = false;
                     for (uint32_t j = 0; j < pUserData->count; ++j) {
                         bool propsMatch = true;
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[j]));
                         while (p != nullptr) {
                             if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
                                 propsMatch = false;
@@ -768,14 +774,51 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
                     if (!found) {
                         VP_DEBUG_MSGF("Unsupported queue family defined at profile data index #%u", i);
                         pUserData->supported = false;
+                        return;
                     }
+                }
+
+                // Then check each permutation to ensure that while order of the queue families
+                // doesn't matter, each queue family property criteria is matched with a separate
+                // queue family of the actual device
+                std::vector<uint32_t> permutation(pUserData->count);
+                for (uint32_t i = 0; i < pUserData->count; ++i) {
+                    permutation[i] = i;
+                }
+                bool found = false;
+                do {
+                    bool propsMatch = true;
+                    for (uint32_t i = 0; i < pUserData->pDesc->queueFamilyCount && propsMatch; ++i) {
+                        p = static_cast<VkBaseOutStructure*>(static_cast<void*>(&pProps[permutation[i]]));
+                        while (p != nullptr) {
+                            if (!pUserData->pDesc->pQueueFamilies[i].pfnComparator(p)) {
+                                propsMatch = false;
+                                break;
+                            }
+                            p = p->pNext;
+                        }
+                    }
+                    if (propsMatch) {
+                        found = true;
+                        break;
+                    }
+                } while (std::next_permutation(permutation.begin(), permutation.end()));
+
+                if (!found) {
+                    VP_DEBUG_MSG("Unsupported combination of queue families");
+                    pUserData->supported = false;
                 }
             }
         };
         userData.pfnCb = callback;
 
-        pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
-        if (!userData.supported) {
+        if (userData.count >= userData.pDesc->queueFamilyCount) {
+            pDesc->chainers.pfnQueueFamily(static_cast<VkBaseOutStructure*>(static_cast<void*>(props.data())), &userData, callback);
+            if (!userData.supported) {
+                *pSupported = VK_FALSE;
+            }
+        } else {
+            VP_DEBUG_MSGF("Unsupported number of queue families: device has fewer (%u) than what the profile defines (%u)", userData.count, userData.pDesc->queueFamilyCount);
             *pSupported = VK_FALSE;
         }
     }


### PR DESCRIPTION
Ziga's PR on the layer-side handling of queue family matching made me realize that the previous queue family matching generated to the library is not accurate, as it did check each profile defined queue family's properties, but didn't require the profile defined queue family requirements to be fulfilled by separate queue families of the device.

In the meantime I also found some other bugs in the queue family comparison code, so those are fixed too.