### PR TITLE
issue 167: add REGENERATE_LAYER and FATAL_WARNINGS switches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,10 @@ include(GNUInstallDirs)
 # headers will be used.
 option(REGENERATE_PROFILES "Regenerate profiles source and headers" ON)
 option(REGENERATE_JSONCPP "Regenerate jsoncpp source and headers" ON)
+option(REGENERATE_LAYER "Regenerate profiles layer source" ON)
 if(REGENERATE_PROFILES)
     find_package(PythonInterp 3.7.2 REQUIRED)
-elseif(REGENERATE_JSONCPP)
+elseif(REGENERATE_JSONCPP OR REGENERATE_LAYER)
     find_package(PythonInterp 3 REQUIRED)
 endif()
 
@@ -187,6 +188,37 @@ if (NOT ANDROID)
     else()
         message(STATUS "Fetching and building Vulkan-Loader")
         FetchContent_MakeAvailable(vulkan-loader)
+    endif()
+endif()
+
+# For our own code, turn on warnings-are-errors if set.
+option(FATAL_WARNINGS "Fail builds if there are warnings" ON)
+if(FATAL_WARNINGS)
+    if(MSVC)
+        add_compile_options(/W4 /WX)
+        add_link_options(/WX)
+        # Ignore some warnings that we know we'll generate.  In the future the
+        # code that generates these warnings should be fixed properly.
+        # vk_layer_logging.h provokes:
+        #    warning C4100: 'default_flag_is_spec': unreferenced formal parameter
+        # vk_loader_platform.h provokes:
+        #    warning C4505: unreferenced local function has been removed
+        # jsoncpp.cpp provokes:
+        #    warning C4702: unreachable code
+        # profiles.cpp provokes:
+        #    warning C4244: '=': conversion from 'Json::Value::UInt' to 'uint8_t', possible loss of data
+        #    warning C4458: declaration of 'validator' hides class member
+        #    warning C4189: 'pdd': local variable is initialized but not referenced
+        #    warning C4800: 'VkBool32': forcing value to bool 'true' or 'false' (performance warning)
+        #    warning C4706: assignment within conditional expression
+        # test_validate.cpp provokes:
+        #    warning C4459: declaration of 'validator' hides global declaration
+        # gtest.h provokes:
+        #    warning C4389: '==': signed/unsigned mismatch
+        #    warning C4018: '>=': signed/unsigned mismatch
+        add_compile_options(/wd4100 /wd4505 /wd4702 /wd4244 /wd4458 /wd4189 /wd4800 /wd4706 /wd4459 /wd4389 /wd4018)
+    else()
+        add_compile_options(-Werror)
     endif()
 endif()
 

--- a/layer-utils/vk_layer_settings.cpp
+++ b/layer-utils/vk_layer_settings.cpp
@@ -173,7 +173,7 @@ static std::string GetEnvironment(const char *variable) {
 static std::string string_tolower(const std::string &s) {
     std::string result = s;
     for (auto &c : result) {
-        c = std::tolower(c);
+        c = (char) std::tolower(c);
     }
     return result;
 }
@@ -181,7 +181,7 @@ static std::string string_tolower(const std::string &s) {
 static std::string string_toupper(const std::string &s) {
     std::string result = s;
     for (auto &c : result) {
-        c = std::toupper(c);
+        c = (char) std::toupper(c);
     }
     return result;
 }

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -69,25 +69,26 @@ if (WIN32)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS /bigobj")
     set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS /bigobj")
 else()
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Werror")
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Werror")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith")
 endif()
-
-set(LAYER_PYTHON_FILES ${CMAKE_SOURCE_DIR}/scripts/gen_layer.py) 
-source_group("Python Files" FILES ${LAYER_PYTHON_FILES})
-
-add_custom_target(VpLayer_generate ALL
-    COMMAND ${PYTHON_EXECUTABLE} ${LAYER_PYTHON_FILES} 
-        -registry ${vulkan-headers_SOURCE_DIR}/registry/vk.xml
-        -outLayer ${CMAKE_SOURCE_DIR}/layer/profiles.cpp
-    VERBATIM
-    SOURCES ${LAYER_PYTHON_FILES}
-    DEPENDS ${vulkan-headers_SOURCE_DIR}/registry/vk.xml)
-set_target_properties(VpLayer_generate PROPERTIES FOLDER "Profiles layer")
 
 add_vk_layer(${TARGET_NAME} profiles.cpp vk_layer_table.cpp ${jsoncpp_generated_source} ${jsoncpp_generated_header})
 
-add_dependencies(VkLayer_${TARGET_NAME} VpLayer_generate)
+if(REGENERATE_LAYER)
+    set(LAYER_PYTHON_FILES ${CMAKE_SOURCE_DIR}/scripts/gen_layer.py)
+    source_group("Python Files" FILES ${LAYER_PYTHON_FILES})
+
+    add_custom_target(VpLayer_generate ALL
+        COMMAND ${PYTHON_EXECUTABLE} ${LAYER_PYTHON_FILES}
+            -registry ${vulkan-headers_SOURCE_DIR}/registry/vk.xml
+            -outLayer ${CMAKE_SOURCE_DIR}/layer/profiles.cpp
+        VERBATIM
+        SOURCES ${LAYER_PYTHON_FILES}
+        DEPENDS ${vulkan-headers_SOURCE_DIR}/registry/vk.xml)
+    set_target_properties(VpLayer_generate PROPERTIES FOLDER "Profiles layer")
+    add_dependencies(VkLayer_${TARGET_NAME} VpLayer_generate)
+endif()
 
 # json file creation
 


### PR DESCRIPTION
Addressing issue:

    Build of Vulkan-Profiles fails on Fedora 34
    https://github.com/KhronosGroup/Vulkan-Profiles/issues/167

There are two issues here:

-   Building the Vulkan-Profiles layer requires the Python jsonschema module.

-   Fedora compilers give more warnings that Ubuntu compilers.

The build works if the Python "jsonschema" module is added to the
building system, and if -Werror is removed from layers/CMakeLists.txt.

To avoid requiring users to install "jsonschema", a new switch
REGENERATE_LAYER is provided.  If ON (the default), the layer code
for profiles.cpp is generated normally via the gen_layer.py script.
If OFF, the committed repository code for profiles.cpp is used directly
without first regenerating.  The "vulkansdk" script and the SDK
builds will explicitly turn this OFF.

To handle differing warnings between compilers, a new switch
FATAL_WARNINGS is provided; if ON (the default) all compile warnings
in the project will become errors.  If OFF, compile warnings are
issued but will not block the build.  The "vulkansdk" script will
explicitly turns this OFF.

These changes include additional fixes for existing code that provoked
compiler warnings:

- layer-utils/vk_layer_settings.cpp: add cast to avoid:
     warning C4244: '=': conversion from 'int' to 'char', possible loss of data

and a lot of Windows compiler instructions to ignore particular warnings.
(These warnings should be fixed as a later effort.)