### PR TITLE
script: fix unused variable warnings

### DIFF
--- a/library/include/vulkan/debug/vulkan_profiles.hpp
+++ b/library/include/vulkan/debug/vulkan_profiles.hpp
@@ -8114,8 +8114,6 @@ VPAPI_ATTR VkResult vpCreateInstance(const VpInstanceCreateInfo *pCreateInfo,
     VkApplicationInfo appInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     std::vector<const char*> extensions;
     VkInstanceCreateInfo* pInstanceCreateInfo = nullptr;
-    VkExtensionProperties* pProfileExtensions = nullptr;
-    uint32_t profileExtensionCount = 0;
 
     if (pCreateInfo != nullptr && pCreateInfo->pCreateInfo != nullptr) {
         createInfo = *pCreateInfo->pCreateInfo;
@@ -8727,8 +8725,6 @@ VPAPI_ATTR VkResult vpGetProfileFormats(const VpProfileProperties *pProfile, uin
 }
 
 VPAPI_ATTR void vpGetProfileFormatProperties(const VpProfileProperties *pProfile, VkFormat format, void *pNext) {
-    VkResult result = VK_SUCCESS;
-
     const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfile->profileName);
     if (pDesc == nullptr) return;
 

--- a/library/include/vulkan/vulkan_profiles.hpp
+++ b/library/include/vulkan/vulkan_profiles.hpp
@@ -8076,8 +8076,6 @@ VPAPI_ATTR VkResult vpCreateInstance(const VpInstanceCreateInfo *pCreateInfo,
     VkApplicationInfo appInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     std::vector<const char*> extensions;
     VkInstanceCreateInfo* pInstanceCreateInfo = nullptr;
-    VkExtensionProperties* pProfileExtensions = nullptr;
-    uint32_t profileExtensionCount = 0;
 
     if (pCreateInfo != nullptr && pCreateInfo->pCreateInfo != nullptr) {
         createInfo = *pCreateInfo->pCreateInfo;
@@ -8683,8 +8681,6 @@ VPAPI_ATTR VkResult vpGetProfileFormats(const VpProfileProperties *pProfile, uin
 }
 
 VPAPI_ATTR void vpGetProfileFormatProperties(const VpProfileProperties *pProfile, VkFormat format, void *pNext) {
-    VkResult result = VK_SUCCESS;
-
     const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfile->profileName);
     if (pDesc == nullptr) return;
 

--- a/library/source/debug/vulkan_profiles.cpp
+++ b/library/source/debug/vulkan_profiles.cpp
@@ -7888,8 +7888,6 @@ VPAPI_ATTR VkResult vpCreateInstance(const VpInstanceCreateInfo *pCreateInfo,
     VkApplicationInfo appInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     std::vector<const char*> extensions;
     VkInstanceCreateInfo* pInstanceCreateInfo = nullptr;
-    VkExtensionProperties* pProfileExtensions = nullptr;
-    uint32_t profileExtensionCount = 0;
 
     if (pCreateInfo != nullptr && pCreateInfo->pCreateInfo != nullptr) {
         createInfo = *pCreateInfo->pCreateInfo;
@@ -8501,8 +8499,6 @@ VPAPI_ATTR VkResult vpGetProfileFormats(const VpProfileProperties *pProfile, uin
 }
 
 VPAPI_ATTR void vpGetProfileFormatProperties(const VpProfileProperties *pProfile, VkFormat format, void *pNext) {
-    VkResult result = VK_SUCCESS;
-
     const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfile->profileName);
     if (pDesc == nullptr) return;
 

--- a/library/source/vulkan_profiles.cpp
+++ b/library/source/vulkan_profiles.cpp
@@ -7850,8 +7850,6 @@ VPAPI_ATTR VkResult vpCreateInstance(const VpInstanceCreateInfo *pCreateInfo,
     VkApplicationInfo appInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     std::vector<const char*> extensions;
     VkInstanceCreateInfo* pInstanceCreateInfo = nullptr;
-    VkExtensionProperties* pProfileExtensions = nullptr;
-    uint32_t profileExtensionCount = 0;
 
     if (pCreateInfo != nullptr && pCreateInfo->pCreateInfo != nullptr) {
         createInfo = *pCreateInfo->pCreateInfo;
@@ -8457,8 +8455,6 @@ VPAPI_ATTR VkResult vpGetProfileFormats(const VpProfileProperties *pProfile, uin
 }
 
 VPAPI_ATTR void vpGetProfileFormatProperties(const VpProfileProperties *pProfile, VkFormat format, void *pNext) {
-    VkResult result = VK_SUCCESS;
-
     const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfile->profileName);
     if (pDesc == nullptr) return;
 

--- a/scripts/genvp.py
+++ b/scripts/genvp.py
@@ -522,8 +522,6 @@ VPAPI_ATTR VkResult vpCreateInstance(const VpInstanceCreateInfo *pCreateInfo,
     VkApplicationInfo appInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     std::vector<const char*> extensions;
     VkInstanceCreateInfo* pInstanceCreateInfo = nullptr;
-    VkExtensionProperties* pProfileExtensions = nullptr;
-    uint32_t profileExtensionCount = 0;
 
     if (pCreateInfo != nullptr && pCreateInfo->pCreateInfo != nullptr) {
         createInfo = *pCreateInfo->pCreateInfo;
@@ -1135,8 +1133,6 @@ VPAPI_ATTR VkResult vpGetProfileFormats(const VpProfileProperties *pProfile, uin
 }
 
 VPAPI_ATTR void vpGetProfileFormatProperties(const VpProfileProperties *pProfile, VkFormat format, void *pNext) {
-    VkResult result = VK_SUCCESS;
-
     const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfile->profileName);
     if (pDesc == nullptr) return;
 


### PR DESCRIPTION
if you have set warnings as errors, it causes problems