### PR TITLE
library: Add support for enabling multiple profiles when creating Vulkan instances

### DIFF
--- a/library/test/test_api_create_device.cpp
+++ b/library/test/test_api_create_device.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
 }
 
 TEST(api_create_device_profile, overrite_with_profile_only) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     VkDeviceCreateInfo info = {};
     info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
@@ -62,7 +62,8 @@ TEST(api_create_device_profile, overrite_with_profile_only) {
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult res = vpCreateDevice(scaffold->physicalDevice, &profileInfo, nullptr, &device);
@@ -71,7 +72,7 @@ TEST(api_create_device_profile, overrite_with_profile_only) {
 }
 
 TEST(api_create_device_profile, overrite_with_supported_extensions) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     static const char* extensions[] = {"VK_KHR_image_format_list", "VK_KHR_maintenance3", "VK_KHR_imageless_framebuffer"};
 
@@ -86,7 +87,8 @@ TEST(api_create_device_profile, overrite_with_supported_extensions) {
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
     profileInfo.flags = VP_DEVICE_CREATE_OVERRIDE_EXTENSIONS_BIT;
 
     VkDevice device = VK_NULL_HANDLE;
@@ -96,7 +98,7 @@ TEST(api_create_device_profile, overrite_with_supported_extensions) {
 }
 
 TEST(api_create_device_profile, overrite_with_unsupported_extensions) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     static const char* extensions[] = {"VK_LUNARG_doesnot_exist", "VK_GTRUC_automagic_rendering",
                                        "VK_GTRUC_portability_everywhere"};
@@ -112,7 +114,8 @@ TEST(api_create_device_profile, overrite_with_unsupported_extensions) {
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
     profileInfo.flags = VP_DEVICE_CREATE_OVERRIDE_EXTENSIONS_BIT;
 
     VkDevice device = VK_NULL_HANDLE;
@@ -123,7 +126,7 @@ TEST(api_create_device_profile, overrite_with_unsupported_extensions) {
 
 
 TEST(api_create_device_profile, overrite_with_enabled_features) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     VkPhysicalDeviceFeatures enabledFeatures = {};
     enabledFeatures.robustBufferAccess = VK_TRUE;
@@ -139,7 +142,8 @@ TEST(api_create_device_profile, overrite_with_enabled_features) {
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult res = vpCreateDevice(scaffold->physicalDevice, &profileInfo, nullptr, &device);
@@ -148,7 +152,7 @@ TEST(api_create_device_profile, overrite_with_enabled_features) {
 }
 
 TEST(api_create_device_profile, overrite_with_pnext_features) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     VkPhysicalDeviceSubgroupSizeControlFeaturesEXT deviceFeatures = {};
     deviceFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT;
@@ -167,7 +171,8 @@ TEST(api_create_device_profile, overrite_with_pnext_features) {
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult res = vpCreateDevice(scaffold->physicalDevice, &profileInfo, nullptr, &device);
@@ -176,7 +181,7 @@ TEST(api_create_device_profile, overrite_with_pnext_features) {
 }
 
 TEST(api_create_device_profile, with_extensions_flag) {
-    const VpProfileProperties profile{VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     static const char* extensions[] = {VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME, VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME};
 
@@ -189,7 +194,8 @@ TEST(api_create_device_profile, with_extensions_flag) {
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
 
     // override profile extensions
     {
@@ -227,43 +233,27 @@ TEST(api_create_device_profile, with_extensions_flag) {
         EXPECT_TRUE(device != VK_NULL_HANDLE);
     }
 }
-/*
-TEST(api_get_profile_support, supported_version) {
-    VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
 
-    VkBool32 supported = VK_FALSE;
-    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, &profile, &supported);
-    EXPECT_EQ(VK_TRUE, supported);
-}
-*/
 TEST(api_get_profile_support, supported_desktop_baseline_2022) {
-    VpProfileProperties profile{VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     VkBool32 supported = VK_FALSE;
-    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, &profile, &supported);
+    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, profile, &supported);
     EXPECT_EQ(VK_TRUE, supported);
 }
 
 TEST(api_get_profile_support, unsupported_name) {
-    VpProfileProperties profile{"Bouuahhhh", VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = "Bouuahhhh";
 
     VkBool32 supported = VK_FALSE;
-    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, &profile, &supported);
-    EXPECT_EQ(VK_FALSE, supported);
-}
-
-TEST(api_get_profile_support, unsupported_version) {
-    VpProfileProperties profile{VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION + 1};
-
-    VkBool32 supported = VK_FALSE;
-    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, &profile, &supported);
+    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, profile, &supported);
     EXPECT_EQ(VK_FALSE, supported);
 }
 
 TEST(api_get_profile_support, empty) {
-    VpProfileProperties profile = {};
+    const char* profile = nullptr;
 
     VkBool32 supported = VK_FALSE;
-    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, &profile, &supported);
+    vpGetPhysicalDeviceProfileSupport(scaffold->instance, scaffold->physicalDevice, profile, &supported);
     EXPECT_EQ(VK_FALSE, supported);
 }

--- a/library/test/test_api_reflection.cpp
+++ b/library/test/test_api_reflection.cpp
@@ -61,17 +61,17 @@ TEST(api_get_profiles_beta, partial) {
 }
 
 TEST(api_get_profile_device_extension_properties, full) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfileDeviceExtensionProperties(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfileDeviceExtensionProperties(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(1, propertyCount);
 
     propertyCount = 2;
 
     std::vector<VkExtensionProperties> properties(propertyCount);
-    VkResult result1 = vpGetProfileDeviceExtensionProperties(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfileDeviceExtensionProperties(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_SUCCESS, result1);
     EXPECT_EQ(1, propertyCount);
 
@@ -79,17 +79,17 @@ TEST(api_get_profile_device_extension_properties, full) {
 }
 
 TEST(api_get_profile_device_extension_properties, partial) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, 1};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfileDeviceExtensionProperties(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfileDeviceExtensionProperties(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(37, propertyCount);
 
     propertyCount = 5;
 
     std::vector<VkExtensionProperties> properties(propertyCount);
-    VkResult result1 = vpGetProfileDeviceExtensionProperties(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfileDeviceExtensionProperties(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_INCOMPLETE, result1);
     EXPECT_EQ(5, propertyCount);
 
@@ -98,59 +98,59 @@ TEST(api_get_profile_device_extension_properties, partial) {
 }
 
 TEST(api_get_profile_instance_extension_properties, full) {
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, 1};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfileInstanceExtensionProperties(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfileInstanceExtensionProperties(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(0, propertyCount);
 
     propertyCount = 2;
 
     std::vector<VkExtensionProperties> properties(propertyCount);
-    VkResult result1 = vpGetProfileInstanceExtensionProperties(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfileInstanceExtensionProperties(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_SUCCESS, result1);
     EXPECT_EQ(0, propertyCount);
 }
 
 TEST(api_get_profile_fallbacks, empty) {
-    const VpProfileProperties profile_portability = {VP_LUNARG_DESKTOP_PORTABILITY_2022_NAME, 1};
-    const VpProfileProperties profile_expect = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, 1};
+    const char* profile_portability = VP_LUNARG_DESKTOP_PORTABILITY_2022_NAME;
+    const char* profile_expect = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     uint32_t count = 0;
-    VkResult result0 = vpGetProfileFallbacks(&profile_portability, &count, nullptr);
+    VkResult result0 = vpGetProfileFallbacks(profile_portability, &count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(0, count);
 
     count = 1;
 
     std::vector<VpProfileProperties> data(count);
-    VkResult result1 = vpGetProfileFallbacks(&profile_portability, &count, &data[0]);
+    VkResult result1 = vpGetProfileFallbacks(profile_expect, &count, &data[0]);
     EXPECT_EQ(VK_SUCCESS, result1);
     EXPECT_EQ(0, count);
 }
 
 TEST(api_get_profile_formats, unspecified) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t formatCount = 0;
-    VkResult result0 = vpGetProfileFormats(&profile, &formatCount, nullptr);
+    VkResult result0 = vpGetProfileFormats(profile, &formatCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(0, formatCount);
 }
 
 TEST(api_get_profile_queue_families, unspecified) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t count = 0;
-    VkResult result0 = vpGetProfileQueueFamilyProperties(&profile, &count, nullptr);
+    VkResult result0 = vpGetProfileQueueFamilyProperties(profile, &count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(0, count);
 
     count = 1;
 
     std::vector<VkQueueFamilyProperties2KHR> data(count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR});
-    VkResult result1 = vpGetProfileQueueFamilyProperties(&profile, &count, &data[0]);
+    VkResult result1 = vpGetProfileQueueFamilyProperties(profile, &count, &data[0]);
     EXPECT_EQ(VK_SUCCESS, result1);
     EXPECT_EQ(0, count);
 }
@@ -160,9 +160,9 @@ TEST(api_get_profile_properties, get_properties2) {
     profileProperties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
     profileProperties2.pNext = nullptr;
 
-    const VpProfileProperties Profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, 1};
+    const char* Profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
-    vpGetProfileProperties(&Profile, &profileProperties2);
+    vpGetProfileProperties(Profile, &profileProperties2);
 
     EXPECT_EQ(16384, profileProperties2.properties.limits.maxImageDimension1D);
     EXPECT_EQ(16384, profileProperties2.properties.limits.maxImageDimension2D);
@@ -185,9 +185,9 @@ TEST(api_get_profile_structures, get_properties_chain) {
     properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
     properties2.pNext = &properties1;
 
-    const VpProfileProperties Profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, 1};
+    const char* Profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
-    vpGetProfileProperties(&Profile, &properties2);
+    vpGetProfileProperties(Profile, &properties2);
 
     EXPECT_EQ(1048576, properties0.maxUpdateAfterBindDescriptorsInAllPools);
     EXPECT_EQ(16, properties0.maxPerStageDescriptorUpdateAfterBindSamplers);
@@ -204,9 +204,9 @@ TEST(api_get_profile_structures, get_features) {
     deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     deviceFeatures2.pNext = &deviceVulkan12Features;
 
-    const VpProfileProperties Profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* Profile = VP_KHR_ROADMAP_2022_NAME;
 
-    vpGetProfileFeatures(&Profile, &deviceFeatures2);
+    vpGetProfileFeatures(Profile, &deviceFeatures2);
 
     EXPECT_EQ(VK_TRUE, deviceVulkan12Features.samplerMirrorClampToEdge);
     EXPECT_EQ(VK_FALSE, deviceVulkan12Features.drawIndirectCount);
@@ -232,17 +232,17 @@ TEST(api_get_profile_structures, get_features) {
 }
 
 TEST(api_get_profile_feature_structure_types, properties_full) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfileFeatureStructureTypes(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfileFeatureStructureTypes(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(4, propertyCount);
 
     propertyCount = 5;
 
     std::vector<VkStructureType> properties(propertyCount);
-    VkResult result1 = vpGetProfileFeatureStructureTypes(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfileFeatureStructureTypes(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_SUCCESS, result1);
     EXPECT_EQ(4, propertyCount);
 
@@ -253,17 +253,17 @@ TEST(api_get_profile_feature_structure_types, properties_full) {
 }
 
 TEST(api_get_profile_feature_structure_types, properties_partial) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfileFeatureStructureTypes(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfileFeatureStructureTypes(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(4, propertyCount);
 
     propertyCount = 3;
 
     std::vector<VkStructureType> properties(propertyCount);
-    VkResult result1 = vpGetProfileFeatureStructureTypes(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfileFeatureStructureTypes(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_INCOMPLETE, result1);
     EXPECT_EQ(3, propertyCount);
 
@@ -273,17 +273,17 @@ TEST(api_get_profile_feature_structure_types, properties_partial) {
 }
 
 TEST(api_get_profile_property_structure_types, properties_full) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfilePropertyStructureTypes(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfilePropertyStructureTypes(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(4, propertyCount);
 
     propertyCount = 5;
 
     std::vector<VkStructureType> properties(propertyCount);
-    VkResult result1 = vpGetProfilePropertyStructureTypes(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfilePropertyStructureTypes(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_SUCCESS, result1);
     EXPECT_EQ(4, propertyCount);
 
@@ -294,17 +294,17 @@ TEST(api_get_profile_property_structure_types, properties_full) {
 }
 
 TEST(api_get_profile_property_structure_types, properties_partial) {
-    const VpProfileProperties profile = {VP_KHR_ROADMAP_2022_NAME, 1};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     uint32_t propertyCount = 0;
-    VkResult result0 = vpGetProfilePropertyStructureTypes(&profile, &propertyCount, nullptr);
+    VkResult result0 = vpGetProfilePropertyStructureTypes(profile, &propertyCount, nullptr);
     EXPECT_EQ(VK_SUCCESS, result0);
     EXPECT_EQ(4, propertyCount);
 
     propertyCount = 3;
 
     std::vector<VkStructureType> properties(propertyCount);
-    VkResult result1 = vpGetProfilePropertyStructureTypes(&profile, &propertyCount, &properties[0]);
+    VkResult result1 = vpGetProfilePropertyStructureTypes(profile, &propertyCount, &properties[0]);
     EXPECT_EQ(VK_INCOMPLETE, result1);
     EXPECT_EQ(3, propertyCount);
 

--- a/library/test/test_mocked_api_create_device.cpp
+++ b/library/test/test_mocked_api_create_device.cpp
@@ -563,7 +563,7 @@ TEST(mocked_api_create_device, disable_robust_buffer_access) {
 TEST(mocked_api_create_device, disable_robust_image_access) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -610,7 +610,7 @@ TEST(mocked_api_create_device, disable_robust_image_access) {
 TEST(mocked_api_create_device, disable_robust_access) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char *profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -646,7 +646,7 @@ TEST(mocked_api_create_device, disable_robust_access) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_DISABLE_ROBUST_ACCESS };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_DISABLE_ROBUST_ACCESS };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);

--- a/library/test/test_mocked_api_create_device.cpp
+++ b/library/test/test_mocked_api_create_device.cpp
@@ -70,7 +70,6 @@ TEST(mocked_api_create_device, default_extensions_negative) {
     MockVulkanAPI mock;
 
     const char *profile = VP_KHR_ROADMAP_2022_NAME;
-};
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -148,7 +147,7 @@ TEST(mocked_api_create_device, override_extensions) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -169,7 +168,7 @@ TEST(mocked_api_create_device, override_extensions) {
 TEST(mocked_api_create_device, merge_extensions) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -201,7 +200,7 @@ TEST(mocked_api_create_device, merge_extensions) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -210,7 +209,7 @@ TEST(mocked_api_create_device, merge_extensions) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_MERGE_EXTENSIONS_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_MERGE_EXTENSIONS_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -222,7 +221,7 @@ TEST(mocked_api_create_device, merge_extensions) {
 TEST(mocked_api_create_device, default_features) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -246,7 +245,7 @@ TEST(mocked_api_create_device, default_features) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -255,7 +254,7 @@ TEST(mocked_api_create_device, default_features) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, 0 };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, 0 };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -267,7 +266,7 @@ TEST(mocked_api_create_device, default_features) {
 TEST(mocked_api_create_device, default_features_negative) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -294,7 +293,7 @@ TEST(mocked_api_create_device, default_features_negative) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -303,7 +302,7 @@ TEST(mocked_api_create_device, default_features_negative) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, 0 };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, 0 };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -318,7 +317,7 @@ TEST(mocked_api_create_device, default_features_negative) {
 TEST(mocked_api_create_device, override_features) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -347,7 +346,7 @@ TEST(mocked_api_create_device, override_features) {
 
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures12 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -357,7 +356,7 @@ TEST(mocked_api_create_device, override_features) {
         VK_STRUCT(inMaint4Features)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_OVERRIDE_FEATURES_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_OVERRIDE_FEATURES_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -369,7 +368,7 @@ TEST(mocked_api_create_device, override_features) {
 TEST(mocked_api_create_device, override_all_features) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -402,7 +401,7 @@ TEST(mocked_api_create_device, override_all_features) {
         VK_STRUCT(inMaint4Features)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -414,7 +413,7 @@ TEST(mocked_api_create_device, override_all_features) {
 TEST(mocked_api_create_device, legacy_enabled_features) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -446,7 +445,7 @@ TEST(mocked_api_create_device, legacy_enabled_features) {
     VkPhysicalDeviceVulkan13Features outFeatures13{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES };
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
-    vpGetProfileFeatures(&profile, &outFeatures11);
+    vpGetProfileFeatures(profile, &outFeatures11);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(inFeatures),
@@ -456,7 +455,7 @@ TEST(mocked_api_create_device, legacy_enabled_features) {
         VK_STRUCT(multiviewFeatures)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_OVERRIDE_FEATURES_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_OVERRIDE_FEATURES_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -468,7 +467,7 @@ TEST(mocked_api_create_device, legacy_enabled_features) {
 TEST(mocked_api_create_device, legacy_enabled_features_override_all) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -503,7 +502,7 @@ TEST(mocked_api_create_device, legacy_enabled_features_override_all) {
         VK_STRUCT(multiviewFeatures)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -515,7 +514,7 @@ TEST(mocked_api_create_device, legacy_enabled_features_override_all) {
 TEST(mocked_api_create_device, disable_robust_buffer_access) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -539,7 +538,7 @@ TEST(mocked_api_create_device, disable_robust_buffer_access) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     outFeatures.features.robustBufferAccess = VK_FALSE;
 
@@ -550,7 +549,7 @@ TEST(mocked_api_create_device, disable_robust_buffer_access) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_DISABLE_ROBUST_BUFFER_ACCESS_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_DISABLE_ROBUST_BUFFER_ACCESS_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -587,7 +586,7 @@ TEST(mocked_api_create_device, disable_robust_image_access) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     outFeatures13.robustImageAccess = VK_FALSE;
 
@@ -634,7 +633,7 @@ TEST(mocked_api_create_device, disable_robust_access) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     outFeatures.features.robustBufferAccess = VK_FALSE;
     outFeatures13.robustImageAccess = VK_FALSE;

--- a/library/test/test_mocked_api_create_device.cpp
+++ b/library/test/test_mocked_api_create_device.cpp
@@ -24,7 +24,7 @@
 TEST(mocked_api_create_device, default_extensions) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -48,7 +48,7 @@ TEST(mocked_api_create_device, default_extensions) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(VP_KHR_ROADMAP_2022_NAME, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -57,7 +57,7 @@ TEST(mocked_api_create_device, default_extensions) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, 0 };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, 0 };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -69,7 +69,8 @@ TEST(mocked_api_create_device, default_extensions) {
 TEST(mocked_api_create_device, default_extensions_negative) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char *profile = VP_KHR_ROADMAP_2022_NAME;
+};
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -100,7 +101,7 @@ TEST(mocked_api_create_device, default_extensions_negative) {
     VkPhysicalDeviceVulkan12Features outFeatures12{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &outFeatures13 };
     VkPhysicalDeviceVulkan11Features outFeatures11{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &outFeatures12 };
     VkPhysicalDeviceFeatures2 outFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &outFeatures11 };
-    vpGetProfileFeatures(&profile, &outFeatures);
+    vpGetProfileFeatures(profile, &outFeatures);
 
     mock.SetExpectedDeviceCreateInfo(&outCreateInfo, {
         VK_STRUCT(outFeatures),
@@ -109,7 +110,7 @@ TEST(mocked_api_create_device, default_extensions_negative) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, 0 };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, 0 };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -124,7 +125,7 @@ TEST(mocked_api_create_device, default_extensions_negative) {
 TEST(mocked_api_create_device, override_extensions) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkDeviceQueueCreateInfo queueCreateInfo{ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
     queueCreateInfo.queueFamilyIndex = 0;
@@ -156,7 +157,7 @@ TEST(mocked_api_create_device, override_extensions) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_OVERRIDE_EXTENSIONS_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_OVERRIDE_EXTENSIONS_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);
@@ -597,7 +598,7 @@ TEST(mocked_api_create_device, disable_robust_image_access) {
         VK_STRUCT(outFeatures13)
     });
 
-    VpDeviceCreateInfo createInfo{ &inCreateInfo, &profile, VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT };
+    VpDeviceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT };
 
     VkDevice device = VK_NULL_HANDLE;
     VkResult result = vpCreateDevice(mock.vkPhysicalDevice, &createInfo, &mock.vkAllocator, &device);

--- a/library/test/test_mocked_api_create_instance.cpp
+++ b/library/test/test_mocked_api_create_instance.cpp
@@ -25,7 +25,7 @@
 TEST(mocked_api_create_instance, vulkan10_no_app_info) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     std::vector<const char*> dummyLayerNames{ "VK_DUMMY_layer1", "VK_DUMMY_layer2" };
 
@@ -45,7 +45,7 @@ TEST(mocked_api_create_instance, vulkan10_no_app_info) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -57,7 +57,7 @@ TEST(mocked_api_create_instance, vulkan10_no_app_info) {
 TEST(mocked_api_create_instance, vulkan10_with_app_info) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     std::vector<const char*> dummyLayerNames{ "VK_DUMMY_layer1" };
 
@@ -81,7 +81,7 @@ TEST(mocked_api_create_instance, vulkan10_with_app_info) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -93,7 +93,7 @@ TEST(mocked_api_create_instance, vulkan10_with_app_info) {
 TEST(mocked_api_create_instance, vulkan11) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     std::vector<const char*> dummyLayerNames{ "VK_DUMMY_layer1", "VK_DUMMY_layer2", "VK_DUMMY_layer3" };
 
@@ -113,7 +113,7 @@ TEST(mocked_api_create_instance, vulkan11) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -125,7 +125,7 @@ TEST(mocked_api_create_instance, vulkan11) {
 TEST(mocked_api_create_instance, default_extensions) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkApplicationInfo inAppInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     inAppInfo.apiVersion = VK_API_VERSION_1_1;
@@ -145,7 +145,7 @@ TEST(mocked_api_create_instance, default_extensions) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, 0 };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, 0 };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -157,7 +157,7 @@ TEST(mocked_api_create_instance, default_extensions) {
 TEST(mocked_api_create_instance, default_extensions_negative) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkApplicationInfo inAppInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     inAppInfo.apiVersion = VK_API_VERSION_1_1;
@@ -185,7 +185,7 @@ TEST(mocked_api_create_instance, default_extensions_negative) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, 0 };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, 0 };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -200,7 +200,7 @@ TEST(mocked_api_create_instance, default_extensions_negative) {
 TEST(mocked_api_create_instance, override_extensions) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkApplicationInfo inAppInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     inAppInfo.apiVersion = VK_API_VERSION_1_1;
@@ -220,7 +220,7 @@ TEST(mocked_api_create_instance, override_extensions) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -232,7 +232,7 @@ TEST(mocked_api_create_instance, override_extensions) {
 TEST(mocked_api_create_instance, merge_extensions) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkApplicationInfo inAppInfo{ VK_STRUCTURE_TYPE_APPLICATION_INFO };
     inAppInfo.apiVersion = VK_API_VERSION_1_1;
@@ -261,7 +261,7 @@ TEST(mocked_api_create_instance, merge_extensions) {
 
     mock.SetExpectedInstanceCreateInfo(&outCreateInfo, {});
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, VP_INSTANCE_CREATE_MERGE_EXTENSIONS_BIT };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_INSTANCE_CREATE_MERGE_EXTENSIONS_BIT };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);
@@ -274,7 +274,7 @@ TEST(mocked_api_create_instance, merge_extensions) {
 TEST(mocked_api_create_instance, retain_chained_structs) {
     MockVulkanAPI mock;
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     int dummyData;
     VkValidationFlagsEXT validationFlags{ VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT };
@@ -301,7 +301,7 @@ TEST(mocked_api_create_instance, retain_chained_structs) {
         VK_STRUCT(debugReportCallback),
     });
 
-    VpInstanceCreateInfo createInfo{ &inCreateInfo, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
+    VpInstanceCreateInfo createInfo{ &inCreateInfo, 1, &profile, VP_INSTANCE_CREATE_OVERRIDE_EXTENSIONS_BIT };
 
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vpCreateInstance(&createInfo, &mock.vkAllocator, &instance);

--- a/library/test/test_mocked_api_get_instance_profile_support.cpp
+++ b/library/test/test_mocked_api_get_instance_profile_support.cpp
@@ -44,10 +44,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan10_supported) {
         VK_EXT(VK_EXT_SWAPCHAIN_COLOR_SPACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_FALSE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_TRUE);
@@ -75,10 +73,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan10_no_gpdp2) {
         VK_EXT(VK_EXT_SWAPCHAIN_COLOR_SPACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -102,10 +98,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan10_unsupported_version) {
         VK_EXT(VK_KHR_EXTERNAL_FENCE_CAPABILITIES),
     });
 
-    const VpProfileProperties profile{VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
-
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_LUNARG_DESKTOP_BASELINE_2022_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -132,10 +126,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan10_unsupported_extension) {
         VK_EXT(VK_EXT_SWAPCHAIN_COLOR_SPACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -159,10 +151,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan11_supported) {
         VK_EXT(VK_EXT_SWAPCHAIN_COLOR_SPACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_FALSE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_TRUE);
@@ -188,10 +178,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan11_unsupported_version) {
         VK_EXT(VK_KHR_EXTERNAL_FENCE_CAPABILITIES),
     });
 
-    VpProfileProperties profile{ VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION };
-
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_KHR_ROADMAP_2022_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -220,10 +208,8 @@ TEST(mocked_api_get_instance_profile_support, vulkan11_unsupported_extension) {
         VK_EXT(VK_EXT_SWAPCHAIN_COLOR_SPACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetInstanceProfileSupport(nullptr, &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport(nullptr, VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -247,10 +233,8 @@ TEST(mocked_api_get_instance_profile_support, layer_supported) {
         VK_EXT(VK_EXT_SWAPCHAIN_COLOR_SPACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_FALSE;
-    VkResult result = vpGetInstanceProfileSupport("VK_DUMMY_layer1", &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport("VK_DUMMY_layer1", VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_TRUE);
@@ -290,10 +274,8 @@ TEST(mocked_api_get_instance_profile_support, layer_unsupported) {
         VK_EXT(VK_KHR_SURFACE),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
-
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetInstanceProfileSupport("VK_DUMMY_layer2", &profile, &supported);
+    VkResult result = vpGetInstanceProfileSupport("VK_DUMMY_layer2", VP_ANDROID_BASELINE_2021_NAME, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);

--- a/library/test/test_mocked_api_get_physdev_profile_support.cpp
+++ b/library/test/test_mocked_api_get_physdev_profile_support.cpp
@@ -62,11 +62,11 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_supported) {
         VK_EXT(VK_GOOGLE_DISPLAY_TIMING),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkPhysicalDeviceMultiviewFeaturesKHR multiviewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR };
     VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR, &multiviewFeatures };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     features.features.dualSrcBlend = VK_TRUE;
     features.features.drawIndirectFirstInstance = VK_TRUE;
     multiviewFeatures.multiview = VK_TRUE;
@@ -77,7 +77,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_supported) {
 
     VkPhysicalDeviceMultiviewPropertiesKHR multiviewProps{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR };
     VkPhysicalDeviceProperties2KHR props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR, &multiviewProps };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     props.properties.limits.maxImageDimension2D = 16384;
     props.properties.limits.maxBoundDescriptorSets = 8;
     props.properties.limits.subPixelPrecisionBits = 8;
@@ -96,12 +96,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_supported) {
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         mock.AddFormat(formats[i], { VK_STRUCT(formatProps) });
@@ -115,7 +115,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_supported) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_FALSE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_TRUE);
@@ -147,11 +147,11 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_no_gpdp2) {
         VK_EXT(VK_GOOGLE_DISPLAY_TIMING),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkPhysicalDeviceMultiviewFeaturesKHR multiviewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR };
     VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR, &multiviewFeatures };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     features.features.dualSrcBlend = VK_TRUE;
     features.features.drawIndirectFirstInstance = VK_TRUE;
     multiviewFeatures.multiview = VK_TRUE;
@@ -162,7 +162,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_no_gpdp2) {
 
     VkPhysicalDeviceMultiviewPropertiesKHR multiviewProps{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR };
     VkPhysicalDeviceProperties2KHR props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR, &multiviewProps };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     props.properties.limits.maxImageDimension2D = 16384;
     props.properties.limits.maxBoundDescriptorSets = 8;
     props.properties.limits.subPixelPrecisionBits = 8;
@@ -181,12 +181,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_no_gpdp2) {
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         mock.AddFormat(formats[i], { VK_STRUCT(formatProps) });
@@ -200,7 +200,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_no_gpdp2) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_ERROR_EXTENSION_NOT_PRESENT);
     EXPECT_EQ(supported, VK_TRUE);
@@ -226,13 +226,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_version) {
         VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
     mock.SetFeatures({
         VK_STRUCT(features), VK_STRUCT(vulkan11Features), VK_STRUCT(vulkan12Features), VK_STRUCT(vulkan13Features)
@@ -242,19 +242,19 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_version) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     mock.SetProperties(
         {VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         mock.AddFormat(formats[i], { VK_STRUCT(formatProps) });
@@ -280,7 +280,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_version) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -321,11 +321,11 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_extension) {
         // Unsupported extension: VK_GOOGLE_display_timing
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkPhysicalDeviceMultiviewFeaturesKHR multiviewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR };
     VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR, &multiviewFeatures };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     features.features.dualSrcBlend = VK_TRUE;
     features.features.drawIndirectFirstInstance = VK_TRUE;
     multiviewFeatures.multiview = VK_TRUE;
@@ -336,7 +336,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_extension) {
 
     VkPhysicalDeviceMultiviewPropertiesKHR multiviewProps{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR };
     VkPhysicalDeviceProperties2KHR props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR, &multiviewProps };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     props.properties.limits.maxImageDimension2D = 16384;
     props.properties.limits.maxBoundDescriptorSets = 8;
     props.properties.limits.subPixelPrecisionBits = 8;
@@ -355,12 +355,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_extension) {
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         mock.AddFormat(formats[i], { VK_STRUCT(formatProps) });
@@ -374,7 +374,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_extension) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -415,11 +415,11 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_feature) {
         VK_EXT(VK_GOOGLE_DISPLAY_TIMING),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkPhysicalDeviceMultiviewFeaturesKHR multiviewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR };
     VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR, &multiviewFeatures };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     features.features.sampleRateShading = VK_FALSE; // Unsupported feature
     features.features.dualSrcBlend = VK_TRUE;
     features.features.drawIndirectFirstInstance = VK_TRUE;
@@ -431,7 +431,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_feature) {
 
     VkPhysicalDeviceMultiviewPropertiesKHR multiviewProps{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR };
     VkPhysicalDeviceProperties2KHR props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR, &multiviewProps };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     props.properties.limits.maxImageDimension2D = 16384;
     props.properties.limits.maxBoundDescriptorSets = 8;
     props.properties.limits.subPixelPrecisionBits = 8;
@@ -450,12 +450,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_feature) {
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         mock.AddFormat(formats[i], { VK_STRUCT(formatProps) });
@@ -469,7 +469,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_feature) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -510,11 +510,11 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_property) {
         VK_EXT(VK_GOOGLE_DISPLAY_TIMING),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkPhysicalDeviceMultiviewFeaturesKHR multiviewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR };
     VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR, &multiviewFeatures };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     features.features.dualSrcBlend = VK_TRUE;
     features.features.drawIndirectFirstInstance = VK_TRUE;
     multiviewFeatures.multiview = VK_TRUE;
@@ -525,7 +525,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_property) {
 
     VkPhysicalDeviceMultiviewPropertiesKHR multiviewProps{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR };
     VkPhysicalDeviceProperties2KHR props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR, &multiviewProps };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     props.properties.limits.maxImageDimension2D = 2048; // Unsupported property
     props.properties.limits.maxBoundDescriptorSets = 8;
     props.properties.limits.subPixelPrecisionBits = 8;
@@ -544,12 +544,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_property) {
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         mock.AddFormat(formats[i], { VK_STRUCT(formatProps) });
@@ -563,7 +563,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_property) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -610,11 +610,11 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_format) {
         VK_EXT(VK_GOOGLE_DISPLAY_TIMING),
     });
 
-    VpProfileProperties profile{ VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION };
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     VkPhysicalDeviceMultiviewFeaturesKHR multiviewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR };
     VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR, &multiviewFeatures };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     mock.SetFeatures({
         VK_STRUCT(features),
         VK_STRUCT(multiviewFeatures)
@@ -622,19 +622,19 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_format) {
 
     VkPhysicalDeviceMultiviewPropertiesKHR multiviewProps{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHR };
     VkPhysicalDeviceProperties2KHR props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR, &multiviewProps };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     mock.SetProperties({
         VK_STRUCT(props),
         VK_STRUCT(multiviewProps)
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         formatProps.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_BLIT_SRC_BIT;
         formatProps.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT;
         if (formats[i] == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32) {
@@ -651,7 +651,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan10_unsupported_format) {
     mock.AddQueueFamily({ VK_STRUCT(queueFamilyProps) });
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -676,13 +676,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan11_unsupported_version) {
         VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
     mock.SetFeatures({VK_STRUCT(features), VK_STRUCT(vulkan11Features), VK_STRUCT(vulkan12Features), VK_STRUCT(vulkan13Features)});
 
@@ -690,18 +690,18 @@ TEST(mocked_api_get_physdev_profile_support, vulkan11_unsupported_version) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     mock.SetProperties(
         {VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)});
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR};
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         mock.AddFormat(formats[i], {VK_STRUCT(formatProps)});
     }
 
@@ -726,7 +726,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan11_unsupported_version) {
     mock.AddQueueFamily({VK_STRUCT(queueFamilyProps)});
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -751,13 +751,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_extension) {
         // Unsupported extension: VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
     mock.SetFeatures({VK_STRUCT(features), VK_STRUCT(vulkan11Features), VK_STRUCT(vulkan12Features), VK_STRUCT(vulkan13Features)});
 
@@ -765,12 +765,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_extension) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     mock.SetProperties({VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)});
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -795,13 +795,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_feature) {
         VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
     features.features.fullDrawIndexUint32 = VK_FALSE;
 
@@ -811,12 +811,12 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_feature) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     mock.SetProperties({VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)});
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -840,13 +840,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_property) {
         VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
 
     mock.SetFeatures({VK_STRUCT(features), VK_STRUCT(vulkan11Features), VK_STRUCT(vulkan12Features), VK_STRUCT(vulkan13Features)});
@@ -855,7 +855,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_property) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     props.properties.limits.maxImageDimensionCube = 2048;
 
@@ -863,7 +863,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_unsupported_property) {
         {VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)});
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -887,37 +887,37 @@ TEST(mocked_api_get_physdev_profile_support, vulkan11_unsupported_format) {
     });
 #endif
 
-    const VpProfileProperties profile{VP_ANDROID_BASELINE_2021_NAME, VP_ANDROID_BASELINE_2021_SPEC_VERSION};
+    const char* profile = VP_ANDROID_BASELINE_2021_NAME;
 
     mock.SetInstanceAPIVersion(VK_API_VERSION_1_1);
     mock.SetDeviceAPIVersion(VK_API_VERSION_1_1);
 
     uint32_t extensionsCount = 0;
-    vpGetProfileDeviceExtensionProperties(&profile, &extensionsCount, nullptr);
+    vpGetProfileDeviceExtensionProperties(profile, &extensionsCount, nullptr);
 
     std::vector<VkExtensionProperties> extensions(extensionsCount);
-    vpGetProfileDeviceExtensionProperties(&profile, &extensionsCount, &extensions[0]);
+    vpGetProfileDeviceExtensionProperties(profile, &extensionsCount, &extensions[0]);
     mock.SetDeviceExtensions(mock.vkPhysicalDevice, extensions);
 
     VkPhysicalDeviceFeatures2 features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
     mock.SetFeatures({
         VK_STRUCT(features),
     });
 
     VkPhysicalDeviceProperties2 props{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 };
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
     mock.SetProperties({
         VK_STRUCT(props),
     });
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{ VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR };
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         if (formats[i] == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32) {
             formatProps.formatProperties.optimalTilingFeatures = 0; // Unsupported format
         }
@@ -925,7 +925,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan11_unsupported_format) {
     }
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_FALSE);
@@ -950,13 +950,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_supported_queue_family) {
         VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    const VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
     mock.SetFeatures({VK_STRUCT(features), VK_STRUCT(vulkan11Features), VK_STRUCT(vulkan12Features), VK_STRUCT(vulkan13Features)});
 
@@ -964,18 +964,18 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_supported_queue_family) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     mock.SetProperties(
         {VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)});
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR};
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         mock.AddFormat(formats[i], {VK_STRUCT(formatProps)});
     }
 
@@ -1000,7 +1000,7 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_supported_queue_family) {
     mock.AddQueueFamily({VK_STRUCT(queueFamilyProps)});
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_TRUE);
@@ -1024,13 +1024,13 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_supported_version) {
         VK_EXT(VK_KHR_GLOBAL_PRIORITY),
     });
 
-    const VpProfileProperties profile{VP_KHR_ROADMAP_2022_NAME, VP_KHR_ROADMAP_2022_SPEC_VERSION};
+    const char* profile = VP_KHR_ROADMAP_2022_NAME;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     VkPhysicalDeviceVulkan12Features vulkan12Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, &vulkan13Features};
     VkPhysicalDeviceVulkan11Features vulkan11Features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features};
     VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &vulkan11Features};
-    vpGetProfileFeatures(&profile, &features);
+    vpGetProfileFeatures(profile, &features);
 
     mock.SetFeatures({VK_STRUCT(features), VK_STRUCT(vulkan11Features), VK_STRUCT(vulkan12Features), VK_STRUCT(vulkan13Features)});
 
@@ -1038,23 +1038,23 @@ TEST(mocked_api_get_physdev_profile_support, vulkan13_supported_version) {
     VkPhysicalDeviceVulkan12Properties vulkan12Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &vulkan13Properties};
     VkPhysicalDeviceVulkan11Properties vulkan11Properties{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &vulkan12Properties};
     VkPhysicalDeviceProperties2 props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, &vulkan11Properties};
-    vpGetProfileProperties(&profile, &props);
+    vpGetProfileProperties(profile, &props);
 
     mock.SetProperties(
         {VK_STRUCT(props), VK_STRUCT(vulkan11Properties), VK_STRUCT(vulkan12Properties), VK_STRUCT(vulkan13Properties)});
 
     uint32_t formatCount;
-    vpGetProfileFormats(&profile, &formatCount, nullptr);
+    vpGetProfileFormats(profile, &formatCount, nullptr);
     std::vector<VkFormat> formats(formatCount);
-    vpGetProfileFormats(&profile, &formatCount, formats.data());
+    vpGetProfileFormats(profile, &formatCount, formats.data());
     for (size_t i = 0; i < formatCount; ++i) {
         VkFormatProperties2KHR formatProps{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR};
-        vpGetProfileFormatProperties(&profile, formats[i], &formatProps);
+        vpGetProfileFormatProperties(profile, formats[i], &formatProps);
         mock.AddFormat(formats[i], {VK_STRUCT(formatProps)});
     }
 
     VkBool32 supported = VK_TRUE;
-    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, profile, &supported);
 
     EXPECT_EQ(result, VK_SUCCESS);
     EXPECT_EQ(supported, VK_TRUE);

--- a/library/test/test_util.cpp
+++ b/library/test/test_util.cpp
@@ -222,11 +222,12 @@ TEST(test_library_util, GetDeviceExtensions) {
     info.pNext = nullptr;
     info.pEnabledFeatures = nullptr;
 
-    const VpProfileProperties profile = {VP_LUNARG_DESKTOP_BASELINE_2022_NAME, VP_LUNARG_DESKTOP_BASELINE_2022_SPEC_VERSION};
+    const char* profile = VP_LUNARG_DESKTOP_BASELINE_2022_NAME;
 
     VpDeviceCreateInfo profileInfo = {};
     profileInfo.pCreateInfo = &info;
-    profileInfo.pProfile = &profile;
+    profileInfo.enabledProfileCount = 1;
+    profileInfo.ppEnabledProfileNames = &profile;
 
     {
         info.enabledExtensionCount = 0;

--- a/scripts/gen_profiles_solution.py
+++ b/scripts/gen_profiles_solution.py
@@ -626,6 +626,10 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
         ext.resize(extCount);
     }
 
+    if (pProfileName == nullptr) {
+        return VK_ERROR_UNKNOWN;
+    }
+
     const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfileName);
     if (pDesc == nullptr) return VK_ERROR_UNKNOWN;
 
@@ -676,12 +680,7 @@ VPAPI_ATTR VkResult vpGetPhysicalDeviceProfileSupport(VkInstance instance, VkPhy
     }
 
     *pSupported = VK_TRUE;
-    VP_DEBUG_MSGF("Checking device support for profile %s (%s). You may find the details of the capabilities of this device on https://vulkan.gpuinfo.org/", pProfile->profileName, detail::vpGetDeviceAndDriverInfoString(physicalDevice, userData.gpdp2.pfnGetPhysicalDeviceProperties2).c_str());
-
-    if (pDesc->props.specVersion < pProfile->specVersion) {
-        VP_DEBUG_MSGF("Unsupported profile version: %u", pProfile->specVersion);
-        *pSupported = VK_FALSE;
-    }
+    VP_DEBUG_MSGF("Checking device support for profile %s (%s). You may find the details of the capabilities of this device on https://vulkan.gpuinfo.org/", pProfileName, detail::vpGetDeviceAndDriverInfoString(physicalDevice, userData.gpdp2.pfnGetPhysicalDeviceProperties2).c_str());
 
     {
         VkPhysicalDeviceProperties props{};
@@ -861,125 +860,133 @@ VPAPI_ATTR VkResult vpCreateDevice(VkPhysicalDevice physicalDevice, const VpDevi
         return vkCreateDevice(physicalDevice, pCreateInfo == nullptr ? nullptr : pCreateInfo->pCreateInfo, pAllocator, pDevice);
     }
 
-    const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pCreateInfo->pProfile->profileName);
-    if (pDesc == nullptr) return VK_ERROR_UNKNOWN;
-
     struct UserData {
-        VkPhysicalDevice                physicalDevice;
-        const detail::VpProfileDesc*    pDesc;
-        const VpDeviceCreateInfo*       pCreateInfo;
-        const VkAllocationCallbacks*    pAllocator;
-        VkDevice*                       pDevice;
-        VkResult                        result;
-    } userData{ physicalDevice, pDesc, pCreateInfo, pAllocator, pDevice };
+        VkPhysicalDevice physicalDevice;
+        const detail::VpProfileDesc* pDesc;
+        const VpDeviceCreateInfo* pCreateInfo;
+        const VkAllocationCallbacks* pAllocator;
+        std::vector<const char*> extensions;
+        void* pNext;
+        VkDevice* pDevice;
+        VkResult result;
+    } userData{physicalDevice, nullptr, pCreateInfo, pAllocator, std::vector<const char*>(), const_cast<void*>(pCreateInfo->pCreateInfo->pNext), pDevice, VK_SUCCESS};
 
-    VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR };
-    pDesc->chainers.pfnFeature(static_cast<VkBaseOutStructure*>(static_cast<void*>(&features)), &userData,
-        [](VkBaseOutStructure* p, void* pUser) {
-            UserData* pUserData = static_cast<UserData*>(pUser);
-            const detail::VpProfileDesc* pDesc = pUserData->pDesc;
-            const VpDeviceCreateInfo* pCreateInfo = pUserData->pCreateInfo;
+    for (uint32_t profileIndex = 0, profileCount = pCreateInfo->enabledProfileCount; profileIndex < profileCount; ++profileIndex) {
+        const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pCreateInfo->ppEnabledProfileNames[profileIndex]);
+        if (pDesc == nullptr) return VK_ERROR_UNKNOWN;
 
-            bool merge = (pCreateInfo->flags & VP_DEVICE_CREATE_MERGE_EXTENSIONS_BIT) != 0;
-            bool override = (pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_EXTENSIONS_BIT) != 0;
+        userData.pDesc = pDesc;
 
-            if (!merge && !override && pCreateInfo->pCreateInfo->enabledExtensionCount > 0) {
-                // If neither merge nor override is used then the application must not specify its
-                // own extensions
-                pUserData->result = VK_ERROR_UNKNOWN;
-                return;
-            }
+        VkPhysicalDeviceFeatures2KHR features{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR };
+        pDesc->chainers.pfnFeature(static_cast<VkBaseOutStructure*>(static_cast<void*>(&features)), &userData,
+            [](VkBaseOutStructure* p, void* pUser) {
+                UserData* pUserData = static_cast<UserData*>(pUser);
+                const detail::VpProfileDesc* pDesc = pUserData->pDesc;
+                const VpDeviceCreateInfo* pCreateInfo = pUserData->pCreateInfo;
 
-            std::vector<const char*> extensions;
-            detail::vpGetExtensions(pCreateInfo->pCreateInfo->enabledExtensionCount,
-                                    pCreateInfo->pCreateInfo->ppEnabledExtensionNames,
-                                    pDesc->deviceExtensionCount,
-                                    pDesc->pDeviceExtensions,
-                                    extensions, merge, override);
+                bool merge = (pCreateInfo->flags & VP_DEVICE_CREATE_MERGE_EXTENSIONS_BIT) != 0;
+                bool override = (pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_EXTENSIONS_BIT) != 0;
 
-            VkBaseOutStructure profileStructList;
-            profileStructList.pNext = p;
-            VkPhysicalDeviceFeatures2KHR* pFeatures = static_cast<VkPhysicalDeviceFeatures2KHR*>(static_cast<void*>(p));
-            if (pDesc->feature.pfnFiller != nullptr) {
-                while (p != nullptr) {
-                    pDesc->feature.pfnFiller(p);
-                    p = p->pNext;
+                if (!merge && !override && pCreateInfo->pCreateInfo->enabledExtensionCount > 0) {
+                    // If neither merge nor override is used then the application must not specify its
+                    // own extensions
+                    pUserData->result = VK_ERROR_UNKNOWN;
+                    return;
                 }
-            }
 
-            if (pCreateInfo->pCreateInfo->pEnabledFeatures != nullptr) {
-                pFeatures->features = *pCreateInfo->pCreateInfo->pEnabledFeatures;
-            }
+                detail::vpGetExtensions(pCreateInfo->pCreateInfo->enabledExtensionCount,
+                                        pCreateInfo->pCreateInfo->ppEnabledExtensionNames,
+                                        pDesc->deviceExtensionCount,
+                                        pDesc->pDeviceExtensions,
+                                        pUserData->extensions, merge, override);
 
-            if (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_BUFFER_ACCESS_BIT) {
-                pFeatures->features.robustBufferAccess = VK_FALSE;
-            }
-
-#ifdef VK_EXT_robustness2
-            VkPhysicalDeviceRobustness2FeaturesEXT* pRobustness2FeaturesEXT = static_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(
-                detail::vpGetStructure(pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT));
-            if (pRobustness2FeaturesEXT != nullptr) {
-                if (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_BUFFER_ACCESS_BIT) {
-                    pRobustness2FeaturesEXT->robustBufferAccess2 = VK_FALSE;
-                }
-                if (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT) {
-                    pRobustness2FeaturesEXT->robustImageAccess2 = VK_FALSE;
-                }
-            }
-#endif
-
-#ifdef VK_EXT_image_robustness
-            VkPhysicalDeviceImageRobustnessFeaturesEXT* pImageRobustnessFeaturesEXT = static_cast<VkPhysicalDeviceImageRobustnessFeaturesEXT*>(
-                detail::vpGetStructure(pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT));
-            if (pImageRobustnessFeaturesEXT != nullptr && (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT)) {
-                pImageRobustnessFeaturesEXT->robustImageAccess = VK_FALSE;
-            }
-#endif
-
-#ifdef VK_VERSION_1_3
-            VkPhysicalDeviceVulkan13Features* pVulkan13Features = static_cast<VkPhysicalDeviceVulkan13Features*>(
-                detail::vpGetStructure(pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES));
-            if (pVulkan13Features != nullptr && (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT)) {
-                pVulkan13Features->robustImageAccess = VK_FALSE;
-            }
-#endif
-
-            VkBaseOutStructure* pNext = static_cast<VkBaseOutStructure*>(const_cast<void*>(pCreateInfo->pCreateInfo->pNext));
-            if ((pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT) == 0) {
-                for (uint32_t i = 0; i < pDesc->featureStructTypeCount; ++i) {
-                    const void* pRequested = detail::vpGetStructure(pNext, pDesc->pFeatureStructTypes[i]);
-                    if (pRequested == nullptr) {
-                        VkBaseOutStructure* pPrevStruct = &profileStructList;
-                        VkBaseOutStructure* pCurrStruct = pPrevStruct->pNext;
-                        while (pCurrStruct->sType != pDesc->pFeatureStructTypes[i]) {
-                            pPrevStruct = pCurrStruct;
-                            pCurrStruct = pCurrStruct->pNext;
-                        }
-                        pPrevStruct->pNext = pCurrStruct->pNext;
-                        pCurrStruct->pNext = pNext;
-                        pNext = pCurrStruct;
-                    } else
-                    if ((pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_FEATURES_BIT) == 0) {
-                        // If override is not used then the application must not specify its
-                        // own feature structure for anything that the profile defines
-                        pUserData->result = VK_ERROR_UNKNOWN;
-                        return;
+                VkBaseOutStructure profileStructList;
+                profileStructList.pNext = p;
+                VkPhysicalDeviceFeatures2KHR* pFeatures = static_cast<VkPhysicalDeviceFeatures2KHR*>(static_cast<void*>(p));
+                if (pDesc->feature.pfnFiller != nullptr) {
+                    while (p != nullptr) {
+                        pDesc->feature.pfnFiller(p);
+                        p = p->pNext;
                     }
                 }
-            }
 
-            VkDeviceCreateInfo createInfo{ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
-            createInfo.pNext = pNext;
-            createInfo.queueCreateInfoCount = pCreateInfo->pCreateInfo->queueCreateInfoCount;
-            createInfo.pQueueCreateInfos = pCreateInfo->pCreateInfo->pQueueCreateInfos;
-            createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
-            createInfo.ppEnabledExtensionNames = extensions.data();
-            if (pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT) {
-                createInfo.pEnabledFeatures = pCreateInfo->pCreateInfo->pEnabledFeatures;
+                if (pCreateInfo->pCreateInfo->pEnabledFeatures != nullptr) {
+                    pFeatures->features = *pCreateInfo->pCreateInfo->pEnabledFeatures;
+                }
+
+                if (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_BUFFER_ACCESS_BIT) {
+                    pFeatures->features.robustBufferAccess = VK_FALSE;
+                }
+
+    #ifdef VK_EXT_robustness2
+                VkPhysicalDeviceRobustness2FeaturesEXT* pRobustness2FeaturesEXT = static_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(
+                    detail::vpGetStructure(pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT));
+                if (pRobustness2FeaturesEXT != nullptr) {
+                    if (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_BUFFER_ACCESS_BIT) {
+                        pRobustness2FeaturesEXT->robustBufferAccess2 = VK_FALSE;
+                    }
+                    if (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT) {
+                        pRobustness2FeaturesEXT->robustImageAccess2 = VK_FALSE;
+                    }
+                }
+    #endif
+
+    #ifdef VK_EXT_image_robustness
+                VkPhysicalDeviceImageRobustnessFeaturesEXT* pImageRobustnessFeaturesEXT = static_cast<VkPhysicalDeviceImageRobustnessFeaturesEXT*>(
+                    detail::vpGetStructure(pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT));
+                if (pImageRobustnessFeaturesEXT != nullptr && (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT)) {
+                    pImageRobustnessFeaturesEXT->robustImageAccess = VK_FALSE;
+                }
+    #endif
+
+    #ifdef VK_VERSION_1_3
+                VkPhysicalDeviceVulkan13Features* pVulkan13Features = static_cast<VkPhysicalDeviceVulkan13Features*>(
+                    detail::vpGetStructure(pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES));
+                if (pVulkan13Features != nullptr && (pCreateInfo->flags & VP_DEVICE_CREATE_DISABLE_ROBUST_IMAGE_ACCESS_BIT)) {
+                    pVulkan13Features->robustImageAccess = VK_FALSE;
+                }
+    #endif
+
+                VkBaseOutStructure* pNext = static_cast<VkBaseOutStructure*>(pUserData->pNext);
+
+                if ((pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT) == 0) {
+                    for (uint32_t i = 0; i < pDesc->featureStructTypeCount; ++i) {
+                        const void* pRequested = detail::vpGetStructure(pNext, pDesc->pFeatureStructTypes[i]);
+                        if (pRequested == nullptr) {
+                            VkBaseOutStructure* pPrevStruct = &profileStructList;
+                            VkBaseOutStructure* pCurrStruct = pPrevStruct->pNext;
+                            while (pCurrStruct->sType != pDesc->pFeatureStructTypes[i]) {
+                                pPrevStruct = pCurrStruct;
+                                pCurrStruct = pCurrStruct->pNext;
+                            }
+                            pPrevStruct->pNext = pCurrStruct->pNext;
+                            pCurrStruct->pNext = pNext;
+                            pNext = pCurrStruct;
+                        } else
+                        if ((pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_FEATURES_BIT) == 0) {
+                            // If override is not used then the application must not specify its
+                            // own feature structure for anything that the profile defines
+                            pUserData->result = VK_ERROR_UNKNOWN;
+                            return;
+                        }
+                    }
+                }
+
+                pUserData->pNext = pNext;
             }
-            pUserData->result = vkCreateDevice(pUserData->physicalDevice, &createInfo, pUserData->pAllocator, pUserData->pDevice);
-        }
-    );
+        );
+    }
+
+    VkDeviceCreateInfo createInfo{ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
+    createInfo.pNext = userData.pNext;
+    createInfo.queueCreateInfoCount = pCreateInfo->pCreateInfo->queueCreateInfoCount;
+    createInfo.pQueueCreateInfos = pCreateInfo->pCreateInfo->pQueueCreateInfos;
+    createInfo.enabledExtensionCount = static_cast<uint32_t>(userData.extensions.size());
+    createInfo.ppEnabledExtensionNames = userData.extensions.data();
+    if (pCreateInfo->flags & VP_DEVICE_CREATE_OVERRIDE_ALL_FEATURES_BIT) {
+        createInfo.pEnabledFeatures = pCreateInfo->pCreateInfo->pEnabledFeatures;
+    }
+    userData.result = vkCreateDevice(userData.physicalDevice, &createInfo, userData.pAllocator, userData.pDevice);
 
     return userData.result;
 }
@@ -1029,7 +1036,7 @@ VPAPI_ATTR VkResult vpGetProfileDeviceExtensionProperties(const char* pProfileNa
 }
 
 VPAPI_ATTR void vpGetProfileFeatures(const char* pProfileName, void *pNext) {
-    const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfile->profileName);
+    const detail::VpProfileDesc* pDesc = detail::vpGetProfileDesc(pProfileName);
     if (pDesc != nullptr && pDesc->feature.pfnFiller != nullptr) {
         VkBaseOutStructure* p = static_cast<VkBaseOutStructure*>(pNext);
         while (p != nullptr) {


### PR DESCRIPTION
This PR is breaking Profiles API library backward compatible