### PR TITLE
Updated to more secure vsnprintf to fix deprecation errors with Apple…

### DIFF
--- a/layer-utils/vk_layer_settings.cpp
+++ b/layer-utils/vk_layer_settings.cpp
@@ -67,7 +67,7 @@ static std::string format(const char *message, ...) {
     va_list list;
 
     va_start(list, message);
-    vsprintf(buffer, message, list);
+    vsnprintf(buffer, STRING_BUFFER, message, list);
     va_end(list);
 
     return buffer;

--- a/profiles/test/test_validate.cpp
+++ b/profiles/test/test_validate.cpp
@@ -52,7 +52,7 @@ static std::string format(const char *message, ...) {
     va_list list;
 
     va_start(list, message);
-    vsprintf(buffer, message, list);
+    vsnprintf(buffer, STRING_BUFFER, message, list);
     va_end(list);
 
     return buffer;

--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -210,7 +210,7 @@ std::string format(const char *message, ...) {
     va_list list;
 
     va_start(list, message);
-    vsprintf(buffer, message, list);
+    vsnprintf(buffer, STRING_BUFFER, message, list);
     va_end(list);
 
     return buffer;


### PR DESCRIPTION
The latest compiler update from Apple is now erroring out on these deprecated and "unsafe" versions of vsprintf. This commit replaces them with vsnprintf, and specifies the sizes of the buffers. Confirmed this now build with the latest Apple toolset.