### PR TITLE
cmake: Use generator expression instead of hardcoded paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,6 @@ include(GNUInstallDirs)
 # headers will be used.
 option(PROFILES_BUILD_TESTS "Build profile tests" ON)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Archive output dir.")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Library output dir.")
-set(CMAKE_PDB_OUTPUT_DIRECTORY     "${CMAKE_BINARY_DIR}/bin" CACHE PATH "PDB (MSVC debug symbol)output dir.")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Executable/dll output dir.")
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 set(CMAKE_C_VISIBILITY_PRESET "hidden")

--- a/layer/tests/CMakeLists.txt
+++ b/layer/tests/CMakeLists.txt
@@ -58,20 +58,13 @@ function(LayerTest NAME)
     target_link_libraries(${TEST_NAME} Vulkan::Headers Vulkan::Vulkan GTest::gtest GTest::gtest_main)
     target_compile_definitions(${TEST_NAME} PUBLIC JSON_TEST_FILES_PATH="${CMAKE_SOURCE_DIR}/profiles/test/data/")
 
-    target_compile_definitions(${TEST_NAME} PUBLIC TEST_BINARY_PATH="${CMAKE_BINARY_DIR}/")
+    target_compile_definitions(${TEST_NAME} PUBLIC TEST_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_khronos_profiles>")
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
-    if(WIN32)
-        string(REPLACE ";" "\\;" path "$ENV{PATH}")
-        string(REPLACE "/" "\\" binary_dir "${CMAKE_BINARY_DIR}\\bin")
-        set(run_environment "VK_LAYER_PATH=${binary_dir}" "PATH=${binary_dir}\;${path}")
-    elseif(UNIX)
-        set(run_environment "VK_LAYER_PATH=${CMAKE_BINARY_DIR}/lib" "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}")
-    else()
-        message(FATAL_ERROR "Unsupported Platform ${CMAKE_SYSTEM_NAME}")
-    endif()
+    set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT
+        "VK_LAYER_PATH=$<TARGET_FILE_DIR:VkLayer_khronos_profiles>"
+    )
 
-    set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "${run_environment}")
     set_target_properties(${TEST_NAME} PROPERTIES FOLDER "Profiles layer/Tests")
 endfunction(LayerTest)
 
@@ -122,7 +115,7 @@ function(LayerTestAndroid NAME)
     set(_app_glue_dir ${ANDROID_NDK_HOME}/sources/android/native_app_glue)
     target_compile_definitions(${ANDROID_APK_NAME} PUBLIC
                                JSON_TEST_FILES_PATH="/sdcard/Android/data/com.example.VulkanProfilesLayerTests/files/"
-                               TEST_BINARY_PATH="${CMAKE_BINARY_DIR}/"
+                               TEST_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_khronos_profiles>"
                                PROFILES_LAYER_APK VK_PROTOTYPES
                                )
     target_include_directories(${ANDROID_APK_NAME} PUBLIC
@@ -140,14 +133,14 @@ function(LayerTestAndroid NAME)
     set(_aapt ${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/aapt)
     set(_zipalign ${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/zipalign)
     add_custom_command(TARGET ${ANDROID_APK_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/apk/assets
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEST_FILES_JSON} ${CMAKE_BINARY_DIR}/apk/assets
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/apk/out
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${ANDROID_APK_NAME}> ${CMAKE_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${ANDROID_APK_NAME}>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:VkLayer_khronos_profiles> ${CMAKE_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:VkLayer_khronos_profiles>
-        COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -A ${CMAKE_BINARY_DIR}/apk/assets -F ${CMAKE_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${CMAKE_BINARY_DIR}/apk/out
-        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${CMAKE_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk androiddebugkey
-        COMMAND ${_zipalign} -f 4 ${CMAKE_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${CMAKE_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}.apk
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/apk/assets
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEST_FILES_JSON} ${PROJECT_BINARY_DIR}/apk/assets
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/apk/out
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${ANDROID_APK_NAME}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${ANDROID_APK_NAME}>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:VkLayer_khronos_profiles> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:VkLayer_khronos_profiles>
+        COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -A ${PROJECT_BINARY_DIR}/apk/assets -F ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out
+        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk androiddebugkey
+        COMMAND ${_zipalign} -f 4 ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}.apk
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "${run_environment}")

--- a/layer/tests/profiles_test_helper.cpp
+++ b/layer/tests/profiles_test_helper.cpp
@@ -31,16 +31,6 @@
 
 #include "profiles_test_helper.h"
 
-#ifdef _WIN32
-#ifdef _DEBUG
-static const char* CONFIG_PATH = "bin/Debug";
-#else
-static const char* CONFIG_PATH = "bin/Release";
-#endif
-#else
-static const char* CONFIG_PATH = "lib";
-#endif
-
 // On Android, VK_MAKE_API_VERSION doesn't yet exist.
 #ifndef VK_MAKE_API_VERSION
 #define VK_MAKE_API_VERSION(variant, major, minor, patch) VK_MAKE_VERSION(major, minor, patch)
@@ -145,7 +135,7 @@ VkResult profiles_test::VulkanInstanceBuilder::getPhysicalDevice(Mode mode, VkPh
 VkResult profiles_test::VulkanInstanceBuilder::init(uint32_t apiVersion, void* pNext) {
     _layer_names.push_back("VK_LAYER_KHRONOS_profiles");
 
-    const std::string layer_path = std::string(TEST_BINARY_PATH) + CONFIG_PATH;
+    const std::string layer_path = std::string(TEST_BINARY_PATH);
     profiles_test::setEnvironmentSetting("VK_LAYER_PATH", layer_path.c_str());
 
     VkApplicationInfo app_info{GetDefaultApplicationInfo()};

--- a/library/test/CMakeLists.txt
+++ b/library/test/CMakeLists.txt
@@ -80,12 +80,12 @@ function (create_android_package NAME)
     set(_aapt ${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/aapt)
     set(_zipalign ${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/zipalign)
     add_custom_command(TARGET ${apk_test_target} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/apk/out
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${apk_test_target}> ${CMAKE_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${apk_test_target}>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${NAME}> ${CMAKE_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${NAME}>
-        COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -F ${CMAKE_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk ${CMAKE_BINARY_DIR}/apk/out
-        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${CMAKE_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk androiddebugkey
-        COMMAND ${_zipalign} -f 4 ${CMAKE_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk ${CMAKE_BINARY_DIR}/apk/out/${apk_test_target}.apk
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/apk/out
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${apk_test_target}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${apk_test_target}>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${NAME}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${NAME}>
+        COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -F ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out
+        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk androiddebugkey
+        COMMAND ${_zipalign} -f 4 ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}.apk
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 endfunction(create_android_package)
 


### PR DESCRIPTION
Instead of relying on the output of the binary directory it's best to use generator expressions to properly setup the environment.

$<TARGET_FILE_DIR:VkLayer_khronos_profiles> returns the directory where VkLayer_khronos_profiles ends up and works with debug/release builds.