### PR TITLE
cmake: Fix json installation

### DIFF
--- a/profiles/CMakeLists.txt
+++ b/profiles/CMakeLists.txt
@@ -169,7 +169,7 @@ install(
         VP_LUNARG_desktop_baseline_2023.json
         VP_LUNARG_desktop_portability_2022.json
     DESTINATION
-        "${CMAKE_INSTALL_DATADIR}/vulkan/config/VK_LAYER_KHRONOS_profiles"
+		"Config/VK_LAYER_KHRONOS_profiles"
 )
 
 install(


### PR DESCRIPTION
closes #385

EX installation output:
```
juan@pop-os:~/projects/profiles$ cmake --install build/ --prefix build/install
-- Install configuration: "Debug"
-- Up-to-date: /home/juan/projects/profiles/build/install/Config/VK_LAYER_KHRONOS_profiles/VP_ANDROID_baseline_2021.json
-- Up-to-date: /home/juan/projects/profiles/build/install/Config/VK_LAYER_KHRONOS_profiles/VP_ANDROID_baseline_2022.json
-- Installing: /home/juan/projects/profiles/build/install/Config/VK_LAYER_KHRONOS_profiles/VP_KHR_roadmap_2022.json
-- Installing: /home/juan/projects/profiles/build/install/Config/VK_LAYER_KHRONOS_profiles/VP_LUNARG_desktop_baseline_2022.json
-- Installing: /home/juan/projects/profiles/build/install/Config/VK_LAYER_KHRONOS_profiles/VP_LUNARG_desktop_baseline_2023.json
-- Installing: /home/juan/projects/profiles/build/install/Config/VK_LAYER_KHRONOS_profiles/VP_LUNARG_desktop_portability_2022.json
-- Up-to-date: /home/juan/projects/profiles/build/install/share/vulkan/registry/gen_profiles_file.py
-- Up-to-date: /home/juan/projects/profiles/build/install/share/vulkan/registry/gen_profiles_solution.py
-- Installing: /home/juan/projects/profiles/build/install/share/vulkan/registry/profiles-0.8-latest.json
-- Installing: /home/juan/projects/profiles/build/install/include/vulkan/vulkan_profiles.hpp
-- Installing: /home/juan/projects/profiles/build/install/share/vulkan/explicit_layer.d/VkLayer_khronos_profiles.json
-- Installing: /home/juan/projects/profiles/build/install/lib/libVkLayer_khronos_profiles.so
```

Please double check everything is being installed properly to match the SDK.