### PR TITLE
profile: Fix VkFormatProperties3 setting wrong sType

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -1246,7 +1246,7 @@ bool JsonLoader::GetFormat(const Json::Value &formats, const std::string &format
                            ArrayOfVkFormatProperties3 *dest3) {
     VkFormat format = StringToFormat(format_name);
     VkFormatProperties profile_properties = {};
-    VkFormatProperties3 profile_properties_3 = {};
+    VkFormatProperties3 profile_properties_3 = {VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3};
     const auto &member = formats[format_name];
     for (const auto &name : member.getMemberNames()) {
         const auto &props = member[name];


### PR DESCRIPTION
in `FillFormatPropertiesPNextChain` we are setting the new `VkFormatProperties3` but currently it is removing the `sType` from the original struct