### PR TITLE
layer: add force physical device setting

### DIFF
--- a/layer/VkLayer_khronos_profiles.json.in
+++ b/layer/VkLayer_khronos_profiles.json.in
@@ -188,6 +188,76 @@
             ],
             "settings": [
                 {
+                    "key": "force_device",
+                    "env": "VK_KHRONOS_PROFILES_FORCE_DEVICE",
+                    "label": "Force Device",
+                    "description": "On system with multiple physical devices, force the use of one specific physical device.",
+                    "status": "BETA",
+                    "type": "ENUM",
+                    "default": "FORCE_DEVICE_OFF",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "flags": [
+                        {
+                            "key": "FORCE_DEVICE_OFF",
+                            "label": "Off",
+                            "description": "Let the Vulkan Loader list all the Physical Device."
+                        },
+                        {
+                            "key": "FORCE_DEVICE_WITH_UUID",
+                            "label": "Using Device UUID",
+                            "description": "Force the Physical Device identified by the device UUID.",
+                            "settings": [
+                                {
+                                    "key": "force_device_uuid",
+                                    "env": "VK_KHRONOS_PROFILES_FORCE_DEVICE_UUID",
+                                    "label": "Device UUID",
+                                    "description": "Device UUID of the forced physical devices",
+                                    "status": "STABLE",
+                                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                                    "type": "STRING",
+                                    "default": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            {
+                                                "key": "force_device",
+                                                "value": "FORCE_DEVICE_WITH_UUID"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "key": "FORCE_DEVICE_WITH_NAME",
+                            "label": "Using Device Name",
+                            "description": "Force the Physical Device identified by the device UUID.",
+                            "settings": [
+                                {
+                                    "key": "force_device_name",
+                                    "env": "VK_KHRONOS_PROFILES_FORCE_DEVICE_NAME",
+                                    "label": "Device Name",
+                                    "description": "Device Name of the forced physical devices",
+                                    "status": "STABLE",
+                                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                                    "type": "ENUM",
+                                    "flags": [],
+                                    "default": "${VP_PHYSICAL_DEVICES}",
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            {
+                                                "key": "force_device",
+                                                "value": "FORCE_DEVICE_WITH_NAME"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
                     "key": "profile_file",
                     "env": "VK_KHRONOS_PROFILES_PROFILE_FILE",
                     "label": "Profile Selection",
@@ -220,6 +290,66 @@
                             "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                         }
                     ]
+                },
+                {
+                    "key": "simulate_capabilities",
+                    "env": "VK_KHRONOS_PROFILES_SIMULATE_CAPABILITIES",
+                    "label": "Simulate Profile Capabilities",
+                    "description": "Control of the simulated capabilities of the Vulkan physical device from the selected Vulkan Profile.",
+                    "status": "STABLE",
+                    "type": "FLAGS",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "flags": [
+                        {
+                            "key": "SIMULATE_API_VERSION_BIT",
+                            "label": "Version",
+                            "description": "The Vulkan device will report the API version from the selected Profile. It also overrides the `api-version` set in VkPhysicalDeviceProperties."
+                        },
+                        {
+                            "key": "SIMULATE_FEATURES_BIT",
+                            "label": "Features",
+                            "description": "The Vulkan device will report the features from the selected Profile.",
+                            "settings": [
+                                {
+                                    "key": "default_feature_values",
+                                    "env": "VK_KHRONOS_PROFILES_DEFAULT_FEATURE_VALUES",
+                                    "label": "Unspecified Features",
+                                    "description": "Feature values when not specified in the select Vulkan profiles.",
+                                    "status": "STABLE",
+                                    "type": "ENUM",
+                                    "default": "DEFAULT_FEATURE_VALUES_DEVICE",
+                                    "flags": [
+                                        {
+                                            "key": "DEFAULT_FEATURE_VALUES_DEVICE",
+                                            "label": "Use Device Values",
+                                            "description": "When a feature is not mentionned in the select Vulkan profiles, set is to the physical device value."
+                                        },
+                                        {
+                                            "key": "DEFAULT_FEATURE_VALUES_FALSE",
+                                            "label": "Use False",
+                                            "description": "When a feature is not mentionned in the select Vulkan profiles, set it to false."
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "key": "SIMULATE_PROPERTIES_BIT",
+                            "label": "Properties",
+                            "description": "The Vulkan device will report the properties from the selected Profile."
+                        },
+                        {
+                            "key": "SIMULATE_EXTENSIONS_BIT",
+                            "label": "Device Extensions",
+                            "description": "The Vulkan device will report the extensions from the selected Profile."
+                        },
+                        {
+                            "key": "SIMULATE_FORMATS_BIT",
+                            "label": "Formats",
+                            "description": "The Vulkan device will report the formats from the selected Profile."
+                        }
+                    ],
+                    "default": [ "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT" ]
                 },
                 {
                     "key": "emulate_portability",
@@ -492,66 +622,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "key": "simulate_capabilities",
-                    "env": "VK_KHRONOS_PROFILES_SIMULATE_CAPABILITIES",
-                    "label": "Simulate Profile Capabilities",
-                    "description": "Control of the simulated capabilities of the Vulkan physical device from the selected Vulkan Profile.",
-                    "status": "STABLE",
-                    "type": "FLAGS",
-                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
-                    "flags": [
-                        {
-                            "key": "SIMULATE_API_VERSION_BIT",
-                            "label": "Version",
-                            "description": "The Vulkan device will report the API version from the selected Profile. It also overrides the `api-version` set in VkPhysicalDeviceProperties."
-                        },
-                        {
-                            "key": "SIMULATE_FEATURES_BIT",
-                            "label": "Features",
-                            "description": "The Vulkan device will report the features from the selected Profile.",
-                            "settings": [
-                                {
-                                    "key": "default_feature_values",
-                                    "env": "VK_KHRONOS_PROFILES_DEFAULT_FEATURE_VALUES",
-                                    "label": "Unspecified Features",
-                                    "description": "Feature values when not specified in the select Vulkan profiles.",
-                                    "status": "STABLE",
-                                    "type": "ENUM",
-                                    "default": "DEFAULT_FEATURE_VALUES_DEVICE",
-                                    "flags": [
-                                        {
-                                            "key": "DEFAULT_FEATURE_VALUES_DEVICE",
-                                            "label": "Use Device Values",
-                                            "description": "When a feature is not mentionned in the select Vulkan profiles, set is to the physical device value."
-                                        },
-                                        {
-                                            "key": "DEFAULT_FEATURE_VALUES_FALSE",
-                                            "label": "Use False",
-                                            "description": "When a feature is not mentionned in the select Vulkan profiles, set it to false."
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "key": "SIMULATE_PROPERTIES_BIT",
-                            "label": "Properties",
-                            "description": "The Vulkan device will report the properties from the selected Profile."
-                        },
-                        {
-                            "key": "SIMULATE_EXTENSIONS_BIT",
-                            "label": "Device Extensions",
-                            "description": "The Vulkan device will report the extensions from the selected Profile."
-                        },
-                        {
-                            "key": "SIMULATE_FORMATS_BIT",
-                            "label": "Formats",
-                            "description": "The Vulkan device will report the formats from the selected Profile."
-                        }
-                    ],
-                    "default": [ "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT" ]
                 },
                 {
                     "key": "exclude_device_extensions",

--- a/layer/profiles_settings.h
+++ b/layer/profiles_settings.h
@@ -61,6 +61,14 @@ enum DefaultFeatureValues {
 
 DefaultFeatureValues GetDefaultFeatureValues(const std::string &value);
 
+enum ForceDevice {
+    FORCE_DEVICE_OFF = 0,
+    FORCE_DEVICE_WITH_UUID,
+    FORCE_DEVICE_WITH_NAME
+};
+
+ForceDevice GetForceDevice(const std::string &value);
+
 enum ProfileVariantsMode {
     VARIANTS_MODE_ALL = 0,
     VARIANTS_MODE_FIRST_SUPPORTED
@@ -105,6 +113,9 @@ typedef struct VkProfileLayerSettingsEXT {
     vku::Strings exclude_formats;
     DefaultFeatureValues default_feature_values{DEFAULT_FEATURE_VALUES_DEVICE};
     ProfileVariantsMode profile_variants_mode{VARIANTS_MODE_FIRST_SUPPORTED};
+    ForceDevice force_device;
+    std::string force_device_uuid;
+    std::string force_device_name;
 } VkProfileLayerSettingsEXT;
 
 void InitSettings(const void *pNext);

--- a/layer/profiles_util.cpp
+++ b/layer/profiles_util.cpp
@@ -54,6 +54,16 @@ std::string GetString(const vku::Strings &strings) {
     return result;
 }
 
+std::string GetUUIDString(const uint8_t deviceUUID[VK_UUID_SIZE]) {
+    std::string result;
+
+    for (std::size_t i = 0, n = VK_UUID_SIZE; i < n; ++i) {
+        result += format("%02X", deviceUUID[i]);
+    }
+
+    return result;
+}
+
 std::string format_device_support_string(VkFormatFeatureFlags format_features) {
     if (format_features == 0) return std::string("does not support it");
     return ::format("only supports:\n\t\" % s\"", GetFormatFeatureString(format_features).c_str());

--- a/layer/profiles_util.h
+++ b/layer/profiles_util.h
@@ -47,6 +47,7 @@ std::string format(const char *message, ...);
 
 std::string GetString(const vku::List &list);
 std::string GetString(const vku::Strings &strings);
+std::string GetUUIDString(const uint8_t deviceUUID[VK_UUID_SIZE]);
 
 void WarnMissingFormatFeatures(const std::string &format_name, const std::string &features, VkFormatFeatureFlags profile_features,
                                VkFormatFeatureFlags device_features);

--- a/layer/tests/tests_mechanism.cpp
+++ b/layer/tests/tests_mechanism.cpp
@@ -999,3 +999,29 @@ TEST_F(TestsMechanism, profile_variants_all) {
         inst_builder.reset();
     }
 }
+
+TEST_F(TestsMechanism, force_physical_device) {
+    VkResult err = VK_SUCCESS;
+
+    profiles_test::VulkanInstanceBuilder inst_builder;
+
+    {
+        VkProfileLayerSettingsEXT settings;
+        settings.force_device = FORCE_DEVICE_OFF;
+        settings.force_device_name = "NVIDIA";
+        settings.force_device_uuid = "BC4A01B15641805847A8151A395A80C7";
+
+        err = inst_builder.init(&settings);
+        ASSERT_EQ(err, VK_SUCCESS);
+
+        VkPhysicalDevice gpu;
+        err = inst_builder.getPhysicalDevice(profiles_test::MODE_PROFILE, &gpu);
+        if (err != VK_SUCCESS) {
+            printf("Profile not supported on device, skipping test.\n");
+            inst_builder.reset();
+            return;
+        }
+
+        inst_builder.reset();
+    }
+}


### PR DESCRIPTION
The original plan was to add "force physical device" to the loader but I suggested Charles to do it in the Profiles layer instead.
It's really a Vulkan developer tool and it releaves him from some work on the Vulkan Loader and it's probably a lot quicker and a less risky to do it in the Profiles layer (and with few changes in Vulkan Configurator).

By Device UUID:
![image](https://user-images.githubusercontent.com/62888873/232473243-ea20cb6c-ed9d-44f5-854c-dfbb0ce399f7.png)

By Device Name:
![image](https://user-images.githubusercontent.com/62888873/232834595-a6ce092a-3d5b-4f54-9ea5-4d6af55135db.png)


