### PR TITLE
profile: fix desktop baseline 2023 lineWidthGranularity

### DIFF
--- a/profiles/VP_LUNARG_desktop_baseline_2023/vp_gpuinfo_amd_radeon_pro_vega_48_0_2_2009_osx_13_1.json
+++ b/profiles/VP_LUNARG_desktop_baseline_2023/vp_gpuinfo_amd_radeon_pro_vega_48_0_2_2009_osx_13_1.json
@@ -345,7 +345,6 @@
                             "VK_SAMPLE_COUNT_4_BIT",
                             "VK_SAMPLE_COUNT_8_BIT"
                         ],
-                        "lineWidthGranularity": 0,
                         "maxBoundDescriptorSets": 8,
                         "maxClipDistances": 1073741824,
                         "maxColorAttachments": 8,

--- a/profiles/VP_LUNARG_desktop_baseline_2023/vp_gpuinfo_apple_m1_max_0_2_2011_osx_13_2.json
+++ b/profiles/VP_LUNARG_desktop_baseline_2023/vp_gpuinfo_apple_m1_max_0_2_2011_osx_13_2.json
@@ -361,7 +361,6 @@
                             "VK_SAMPLE_COUNT_2_BIT",
                             "VK_SAMPLE_COUNT_4_BIT"
                         ],
-                        "lineWidthGranularity": 0,
                         "maxBoundDescriptorSets": 8,
                         "maxClipDistances": 8,
                         "maxColorAttachments": 8,

--- a/profiles/VP_LUNARG_desktop_baseline_2023/vp_gpuinfo_intel_r__uhd_graphics_630_0_2_2009_osx_13_2.json
+++ b/profiles/VP_LUNARG_desktop_baseline_2023/vp_gpuinfo_intel_r__uhd_graphics_630_0_2_2009_osx_13_2.json
@@ -339,7 +339,6 @@
                             "VK_SAMPLE_COUNT_4_BIT",
                             "VK_SAMPLE_COUNT_8_BIT"
                         ],
-                        "lineWidthGranularity": 0,
                         "maxBoundDescriptorSets": 8,
                         "maxClipDistances": 1073741824,
                         "maxColorAttachments": 8,


### PR DESCRIPTION
It looks like MoltenVK change (and actually fixed) the report for `lineWidthGranularity` however the desktop 2023 profile is built with old reports so hack a workaround.