### PR TITLE
scripts: Fix rasterization_order_attachment_access exception

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -1050,7 +1050,7 @@ bool JsonLoader::GetFormat(const char *device_name, const Json::Value &formats, 
 
 bool JsonLoader::CheckVersionSupport(uint32_t version, const std::string &name) {
     if (pdd_->GetEffectiveVersion() < version) {
-        LogMessage(&layer_settings, 
+        LogMessage(&layer_settings,
             DEBUG_REPORT_ERROR_BIT,
             "Profile sets %s which is provided by Vulkan version %s, but the current effective API version is %s.\\n",
                      name.c_str(), StringAPIVersion(version).c_str(), StringAPIVersion(pdd_->GetEffectiveVersion()).c_str());
@@ -1079,7 +1079,7 @@ JsonLoader::ExtensionSupport JsonLoader::CheckExtensionSupport(const char *exten
         }
     } else {
         if (!PhysicalDeviceData::HasExtension(pdd_, extension)) {
-            LogMessage(&layer_settings, 
+            LogMessage(&layer_settings,
                 DEBUG_REPORT_WARNING_BIT,
                 "Profile requires by %s capabilities, but %s is not supported by the device.\\n", name.c_str(), extension);
         }
@@ -3104,9 +3104,6 @@ class VulkanProfilesLayerGenerator():
                     continue
                 gen += self.generate_fill_case(property)
             for feature in features:
-                # Currently a bug in the spec, skip
-                if feature == 'VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM':
-                    continue
                 gen += self.generate_fill_case(feature)
 
         gen += '            default:\n'

--- a/scripts/gen_profiles_tests.py
+++ b/scripts/gen_profiles_tests.py
@@ -100,7 +100,7 @@ class TestsCapabilitiesGenerated : public VkTestFramework {
         VkResult err = VK_SUCCESS;
 
         const char* profile_file_data = JSON_TEST_FILES_PATH "VP_LUNARG_test_api_generated.json";
-        const char* profile_name_data = "VP_LUNARG_test_api"; 
+        const char* profile_name_data = "VP_LUNARG_test_api";
         VkBool32 emulate_portability_data = VK_TRUE;
         const std::vector<const char*> simulate_capabilities = {
             "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT", "SIMULATE_EXTENSIONS_BIT", "SIMULATE_FORMATS_BIT", "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT"};
@@ -150,8 +150,7 @@ bool IsSupported(VkPhysicalDevice device, const char* extension_name){
 
 class ProfileGenerator():
     i = 1
-    # Currently a bug in vk.xml, can be removed once pNext is no longer const
-    skipped_features = ["VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"]
+    skipped_features = []
     skipped_members = ["sType", "pNext", "physicalDevices", "driverID"]
 
     def generate_profile(self, outProfile, registry):
@@ -319,7 +318,7 @@ class ProfileGenerator():
                     gen += property_name
                     gen += '\": '
                     #if member.limittype == "":
-                    #    self.test_values[name][property] = 
+                    #    self.test_values[name][property] =
                     if property_type == "VkBool32":
                         gen += "true"
                         self.test_values[name][property] = 'VK_TRUE'
@@ -619,7 +618,7 @@ class ProfileGenerator():
                         # VkConformanceVersion is noauto and unmodified
                         if 'VkConformanceVersion' in member_type:
                             continue
-                        
+
                         gen += '    if (supported) {\n'
                         if type(property_value) is list:
                             if (len(property_value) > 1):
@@ -686,7 +685,7 @@ class ProfileGenerator():
         gen += '    features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;\n'
         gen += '    features.pNext = &' + var_name + ';\n'
         gen += '    vkGetPhysicalDeviceFeatures2(gpu_profile, &features);\n\n'
-        
+
         for member in value.members:
             gen += '    EXPECT_EQ(' + var_name + '.' + member + ', VK_TRUE);\n'
 
@@ -712,7 +711,7 @@ class ProfileGenerator():
         if first:
             gen += '0'
         gen += ';\n'
-        
+
         gen += '    VkFormatFeatureFlags optimal_tiling_features = '
         first = True
         for feature in values[1]:
@@ -724,7 +723,7 @@ class ProfileGenerator():
         if first:
             gen += '0'
         gen += ';\n'
-        
+
         gen += '    VkFormatFeatureFlags buffer_features = '
         first = True
         for feature in values[2]:


### PR DESCRIPTION
seems the XML was fixed when `VK_EXT_rasterization_order_attachment_access` was created

Noticed a VVL test not running even though the features were enabled