### PR TITLE
cmake: Use BUILD_TESTS

### DIFF
--- a/.github/workflows/profiles.yml
+++ b/.github/workflows/profiles.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Add ccache to PATH
         run: echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
       - name: Configure/Generate
-        run: cmake -S. -B build -D PROFILES_BUILD_TESTS=OFF -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=Release -G "Ninja"
+        run: cmake -S. -B build -D BUILD_TESTS=OFF -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=Release -G "Ninja"
         env:
           # Ensure we can build against 10.15: https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html
           MACOSX_DEPLOYMENT_TARGET: 10.15
@@ -85,7 +85,7 @@ jobs:
       - name: Add ccache to PATH
         run: echo "/usr/lib/ccache" >> $GITHUB_PATH
       - name: Configure/Generate
-        run: cmake -S. -B build -D PROFILES_BUILD_TESTS=OFF -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja"
+        run: cmake -S. -B build -D BUILD_TESTS=OFF -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja"
       - name: Build
         run: cmake --build build --config ${{matrix.config}}
       - name: Install
@@ -114,7 +114,7 @@ jobs:
           -D BUILD_WERROR=ON \
           -D CMAKE_BUILD_TYPE=Release \
           -D UPDATE_DEPS=ON \
-          -D PROFILES_BUILD_TESTS=OFF \
+          -D BUILD_TESTS=OFF \
           -G "Ninja"
       - name: Build
         run: cmake --build build
@@ -145,7 +145,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
       - name: Configure/Generate
-        run: cmake -S. -B build -D PROFILES_BUILD_TESTS=OFF -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja"
+        run: cmake -S. -B build -D BUILD_TESTS=OFF -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja"
       - name: Build
         run: cmake --build build --config ${{matrix.config}}
       - name: Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(VULKAN_PROFILES LANGUAGES CXX C)
 
 include(GNUInstallDirs)
 
-option(PROFILES_BUILD_TESTS "Build profile tests" ON)
-
 set(PROFILES_CPP_STANDARD 17 CACHE STRING "Set the C++ standard to build against.")
 set(CMAKE_CXX_STANDARD ${PROFILES_CPP_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -33,7 +31,8 @@ find_package(valijson REQUIRED CONFIG)
 
 find_package(jsoncpp REQUIRED CONFIG)
 
-if(PROFILES_BUILD_TESTS)
+option(BUILD_TESTS "Build the tests")
+if (BUILD_TESTS)
     enable_testing()
     find_package(GTest REQUIRED CONFIG)
 endif()

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(PROFILES_BUILD_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(tests)
 endif()
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -7,7 +7,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_SOURCE_DIR}/library/in
 execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_SOURCE_DIR}/library/source/vulkan_profiles.cpp)
 execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_SOURCE_DIR}/library/source/debug/vulkan_profiles.cpp)
 
-if(PROFILES_BUILD_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(test)
 endif()
 

--- a/profiles/CMakeLists.txt
+++ b/profiles/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (PROFILES_BUILD_TESTS AND NOT ANDROID)
+if (BUILD_TESTS AND NOT ANDROID)
     add_subdirectory(test)
 endif()
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -49,7 +49,7 @@ if (UPDATE_DEPS)
     list(APPEND update_dep_command "--dir" )
     list(APPEND update_dep_command "${UPDATE_DEPS_DIR}")
 
-    if (NOT PROFILES_BUILD_TESTS)
+    if (NOT BUILD_TESTS)
         list(APPEND update_dep_command "--optional=tests")
     endif()
 


### PR DESCRIPTION
Because we routinely have to update `update_deps.py` it's much easier if this variable is consistent across repos using this script.

Also testing should be OFF by default.

This makes the library easier to package/build. This is already done in other vulkan repos we manage.