### PR TITLE
layer: Fix query of capabilities of aliased extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## [Vulkan Profiles Toolset 1.3.261](https://github.com/KhronosGroup/Vulkan-Profiles/tree/main) - August 2023
 
 ### Bugfixes:
+- Fix query of capabilities of aliased extensions
 - Fix error message typo
 
 ## [Vulkan Profiles Toolset 1.3.250](https://github.com/KhronosGroup/Vulkan-Profiles/tree/sdk-1.3.250.0) - June 2023

--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -3323,8 +3323,16 @@ class VulkanProfilesLayerGenerator():
                     first = False
                 else:
                     gen += ' && '
-                gen += 'PhysicalDeviceData::HasSimulatedExtension(physicalDeviceData, '
-                gen += registry.extensions[ext].upperCaseName + '_EXTENSION_NAME'
+                promotedTo = ext
+                while promotedTo != None and promotedTo in registry.extensions:
+                    if promotedTo != ext:
+                        gen += ' || '
+                    else:
+                        gen += '('
+                    gen += 'PhysicalDeviceData::HasSimulatedExtension(physicalDeviceData, '
+                    gen += registry.extensions[promotedTo].upperCaseName + '_EXTENSION_NAME'
+                    gen += ')'
+                    promotedTo = registry.extensions[promotedTo].promotedTo
                 gen += ')'
             gen += ') '
         elif structure.definedByVersion and (structure.definedByVersion.major != 1 or structure.definedByVersion.minor != 0):


### PR DESCRIPTION
This issue was find when using a profile requiring `VK_EXT_mutable_descriptor_type`, when querying the required capabilities in `VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT` the structure was empty because the layer would only check with the aliased extension `VK_VALVE_mutable_descriptor_type`,