### PR TITLE
layer: Fix invalid feature warning

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -348,7 +348,7 @@ WARN_FUNCTIONS = '''
             if (not_modifiable) {
                 LogMessage(layer_settings, DEBUG_REPORT_WARNING_BIT,
                     "'%s' is not modifiable but the profile value (%s) is different from the device (%s) value (%s)\\n", cap_name, new_value ? "true" : "false", device_name, old_value ? "true" : "false");
-            } else {
+            } else if (new_value) {
                 LogMessage(layer_settings, DEBUG_REPORT_WARNING_BIT,
                     "'%s' profile value is enabled in the profile, but the device (%s) does not support it.\\n", cap_name, device_name);
             }


### PR DESCRIPTION
The Profiles layer generates warnings if a profile _**disables**_ a feature that is otherwise _**supported**_ by the device with messages like this:

`'%s' profile value is enabled in the profile, but the device (%s) does not support it.`

That just doesn't make sense, as such warnings should only be generated if a profile would want to _**enable**_ a feature that is _**not supported**_ by the device.

This change fixes that.