### PR TITLE
layer: Fix EnumerateDeviceExtensionProperties segfault

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -2066,11 +2066,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
     if (result == VK_SUCCESS && !pLayerName && layer_settings->simulate.emulate_portability &&
         !PhysicalDeviceData::HasSimulatedOrRealExtension(physicalDevice, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         if (pProperties) {
-            if (pCount_copy == *pCount + 1) {
-                *pCount = pCount_copy;
+            if (pCount_copy >= *pCount + 1) {
+                strncpy(pProperties[*pCount].extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE);
+                pProperties[*pCount].specVersion = VK_KHR_PORTABILITY_SUBSET_SPEC_VERSION;
+                *pCount += 1;
             }
-            strncpy(pProperties[(*pCount) - 1].extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE);
-            pProperties[(*pCount) - 1].specVersion = VK_KHR_PORTABILITY_SUBSET_SPEC_VERSION;
         } else {
             *pCount += 1;
         }


### PR DESCRIPTION
The code that injects `VK_KHR_protability_subset` in `vkEnumerateDeviceExtensionProperties` is all wrong which results in incorrect value returned in `pCount`, as well as causing segfaults if the profile does not include any extensions.

This change fixes that.