### PR TITLE
layer: Fix dispatch table memory leak

### DIFF
--- a/layer/vk_layer_table.h
+++ b/layer/vk_layer_table.h
@@ -1,6 +1,7 @@
 /* Copyright (c) 2015-2022 The Khronos Group Inc.
  * Copyright (c) 2015-2022 Valve Corporation
  * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +22,12 @@
 
 #include "vulkan/vk_layer.h"
 #include "vulkan/vulkan.h"
+#include <memory>
 #include <unordered_map>
 #include "utils/vk_layer_utils.h"
 
-typedef std::unordered_map<void *, VkLayerDispatchTable *> device_table_map;
-typedef std::unordered_map<void *, VkLayerInstanceDispatchTable *> instance_table_map;
+typedef std::unordered_map<void *, std::unique_ptr<VkLayerDispatchTable>> device_table_map;
+typedef std::unordered_map<void *, std::unique_ptr<VkLayerInstanceDispatchTable>> instance_table_map;
 VkLayerDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa, device_table_map &map);
 VkLayerDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa);
 VkLayerInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa, instance_table_map &map);


### PR DESCRIPTION
The Profiles layer leaks memory on exit because the dispatch tables allocated never get destroyed.

This is observable by running some tests with AddressSanitizer.

The source has `destroy_device_dispatch_table` and `destroy_instance_dispatch_table` functions that are supposed to delete these allocations, but they are never called from anywhere.

Instead, this fix simply uses `unique_ptr`s to make sure that these allocations always get released when the layer is unloaded.