### PR TITLE
build: Add support for API parameterization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(VULKAN_PROFILES LANGUAGES CXX C)
 
 include(GNUInstallDirs)
 
+# This variable enables downstream users to customize the target API variant (e.g. Vulkan SC)
+set(API_TYPE "vulkan")
+
 set(PROFILES_CPP_STANDARD 17 CACHE STRING "Set the C++ standard to build against.")
 set(CMAKE_CXX_STANDARD ${PROFILES_CPP_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -1,3 +1,7 @@
+# This variable enables downstream users to customize the CMake targets
+# based on the target API variant (e.g. Vulkan SC)
+set(LAYER_NAME "VkLayer_khronos_profiles")
+
 if(BUILD_TESTS)
     add_subdirectory(tests)
 endif()
@@ -50,26 +54,27 @@ else()
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith")
 endif()
 
-source_group("JSON Manifest" FILES VkLayer_khronos_profiles.json.in)
-source_group("Export Files" FILES VkLayer_khronos_profiles.def VkLayer_khronos_profiles.map)
+source_group("JSON Manifest" FILES ${LAYER_NAME}.json.in)
+source_group("Export Files" FILES ${LAYER_NAME}.def ${LAYER_NAME}.map)
 
-add_library(VkLayer_khronos_profiles MODULE)
-set_target_properties(VkLayer_khronos_profiles PROPERTIES FOLDER "Profiles layer")
+add_library(ProfilesLayer MODULE)
+set_target_properties(ProfilesLayer PROPERTIES FOLDER "Profiles layer")
+set_target_properties(ProfilesLayer PROPERTIES OUTPUT_NAME ${LAYER_NAME})
 
 if (MSVC)
-    target_link_options(VkLayer_khronos_profiles PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_profiles.def)
+    target_link_options(ProfilesLayer PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.def)
 elseif(MINGW)
-    target_sources(VkLayer_khronos_profiles PRIVATE VkLayer_khronos_profiles.def)
+    target_sources(ProfilesLayer PRIVATE ${LAYER_NAME}.def)
 elseif(APPLE)
     message(DEBUG "Functions are exported via PROFILES_EXPORT")
-    set_target_properties(VkLayer_khronos_profiles PROPERTIES SUFFIX ".dylib")
+    set_target_properties(ProfilesLayer PROPERTIES SUFFIX ".dylib")
 elseif(ANDROID)
     message(DEBUG "Functions are exported via PROFILES_EXPORT")
 else()
-    target_link_options(VkLayer_khronos_profiles PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_profiles.map,-Bsymbolic,--exclude-libs,ALL)
+    target_link_options(ProfilesLayer PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.map,-Bsymbolic,--exclude-libs,ALL)
 endif()
 
-target_sources(VkLayer_khronos_profiles PRIVATE
+target_sources(ProfilesLayer PRIVATE
     profiles_interface.cpp
     profiles_interface.h
     profiles_settings.cpp
@@ -81,12 +86,12 @@ target_sources(VkLayer_khronos_profiles PRIVATE
     profiles_generated.cpp
     profiles.h
     vk_layer_table.cpp
-    VkLayer_khronos_profiles.json.in
-    VkLayer_khronos_profiles.def
-    VkLayer_khronos_profiles.map
+    ${LAYER_NAME}.json.in
+    ${LAYER_NAME}.def
+    ${LAYER_NAME}.map
 )
 
-target_link_libraries(VkLayer_khronos_profiles PRIVATE
+target_link_libraries(ProfilesLayer PRIVATE
     Vulkan::LayerSettings
     Vulkan::Headers
     Vulkan::UtilityHeaders
@@ -96,7 +101,7 @@ target_link_libraries(VkLayer_khronos_profiles PRIVATE
 
 if(ANDROID)
     # Android needs -llog for __android_print_log()
-    target_link_Libraries(VkLayer_khronos_profiles PRIVATE log)
+    target_link_Libraries(ProfilesLayer PRIVATE log)
 endif()
 
 set(LAYER_PYTHON_FILES ${CMAKE_SOURCE_DIR}/scripts/gen_profiles_layer.py)
@@ -104,39 +109,41 @@ source_group("Python Files" FILES ${LAYER_PYTHON_FILES})
 
 add_custom_target(VpLayer_generate ALL
     COMMAND Python3::Interpreter ${LAYER_PYTHON_FILES}
+        -api ${API_TYPE}
         -registry ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml
         -outLayer ${CMAKE_SOURCE_DIR}/layer/profiles_generated.cpp
     VERBATIM
     SOURCES ${LAYER_PYTHON_FILES}
     DEPENDS ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml)
 set_target_properties(VpLayer_generate PROPERTIES FOLDER "Profiles layer")
-add_dependencies(VkLayer_khronos_profiles VpLayer_generate)
+add_dependencies(ProfilesLayer VpLayer_generate)
 
 source_group("Python Files" FILES ${CMAKE_SOURCE_DIR}/scripts/gen_profiles_tests.py)
 add_custom_target(VpLayer_generate_tests ALL
 	COMMAND Python3::Interpreter ${CMAKE_SOURCE_DIR}/scripts/gen_profiles_tests.py
+		-api ${API_TYPE}
 		-registry ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml
 		-outProfile ${CMAKE_SOURCE_DIR}/profiles/test/data/VP_LUNARG_test_api_generated.json
 		-outTests ${CMAKE_SOURCE_DIR}/layer/tests/tests_generated.cpp
 	VERBATIM
-	DEPENDS VkLayer_khronos_profiles
+	DEPENDS ProfilesLayer
 	)
 set_target_properties(VpLayer_generate_tests PROPERTIES FOLDER "Profiles layer")
 
-set(INPUT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_profiles.json.in")
+set(INPUT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.json.in")
 set(INTERMEDIATE_FILE "${CMAKE_CURRENT_BINARY_DIR}/json/profile.json")
-set(OUTPUT_FILE_FINAL_NAME "VkLayer_khronos_profiles.json")
+set(OUTPUT_FILE_FINAL_NAME "${LAYER_NAME}.json")
 set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
 if (WIN32)
     set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_BINDIR}) # WIN32/MINGW expect the dll in the `bin` dir, this matches our WIN32 SDK process
 endif()
 
 if (WIN32)
-    set(JSON_LIBRARY_PATH ".\\\\VkLayer_khronos_profiles.dll")
+    set(JSON_LIBRARY_PATH ".\\\\${LAYER_NAME}.dll")
 elseif(APPLE)
-    set(JSON_LIBRARY_PATH "./libVkLayer_khronos_profiles.dylib")
+    set(JSON_LIBRARY_PATH "./lib${LAYER_NAME}.dylib")
 else()
-    set(JSON_LIBRARY_PATH "./libVkLayer_khronos_profiles.so")
+    set(JSON_LIBRARY_PATH "./lib${LAYER_NAME}.so")
 endif()
 
 set(JSON_API_VERSION ${VulkanHeaders_VERSION})
@@ -144,8 +151,8 @@ set(JSON_API_VERSION ${VulkanHeaders_VERSION})
 configure_file(${INPUT_FILE} ${INTERMEDIATE_FILE} @ONLY)
 
 # To support both multi/single configuration generators just copy the json to the correct directory
-add_custom_command(TARGET VkLayer_khronos_profiles POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${INTERMEDIATE_FILE} $<TARGET_FILE_DIR:VkLayer_khronos_profiles>/${OUTPUT_FILE_FINAL_NAME}
+add_custom_command(TARGET ProfilesLayer POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${INTERMEDIATE_FILE} $<TARGET_FILE_DIR:ProfilesLayer>/${OUTPUT_FILE_FINAL_NAME}
 )
 
 # For UNIX-based systems, `library_path` should not contain a relative path (indicated by "./") before installing to system directories
@@ -154,21 +161,21 @@ if (UNIX)
     set(UNIX_INTERMEDIATE_FILE "${CMAKE_CURRENT_BINARY_DIR}/json/unix_install_profile.json")
 
     if(APPLE)
-        set(JSON_LIBRARY_PATH "libVkLayer_khronos_profiles.dylib")
+        set(JSON_LIBRARY_PATH "lib${LAYER_NAME}.dylib")
     else()
-        set(JSON_LIBRARY_PATH "libVkLayer_khronos_profiles.so")
+        set(JSON_LIBRARY_PATH "lib${LAYER_NAME}.so")
     endif()
 
     configure_file(${INPUT_FILE} ${UNIX_INTERMEDIATE_FILE} @ONLY)
 
-    install(FILES ${UNIX_INTERMEDIATE_FILE} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/explicit_layer.d RENAME ${OUTPUT_FILE_FINAL_NAME})
+    install(FILES ${UNIX_INTERMEDIATE_FILE} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${API_TYPE}/explicit_layer.d RENAME ${OUTPUT_FILE_FINAL_NAME})
 endif()
 
 if (WIN32)
     install(FILES ${INTERMEDIATE_FILE} DESTINATION ${LAYER_INSTALL_DIR} RENAME ${OUTPUT_FILE_FINAL_NAME})
 endif()
 if (MSVC)
-    install(FILES $<TARGET_PDB_FILE:VkLayer_khronos_profiles> DESTINATION ${LAYER_INSTALL_DIR})
+    install(FILES $<TARGET_PDB_FILE:ProfilesLayer> DESTINATION ${LAYER_INSTALL_DIR})
 endif()
 
-install(TARGETS VkLayer_khronos_profiles DESTINATION ${LAYER_INSTALL_DIR})
+install(TARGETS ProfilesLayer DESTINATION ${LAYER_INSTALL_DIR})

--- a/layer/tests/CMakeLists.txt
+++ b/layer/tests/CMakeLists.txt
@@ -48,16 +48,16 @@ function(LayerTest NAME)
                    profiles_test_helper.cpp
                    layer_tests_main.cpp
                    vktestframework.cpp)
-    add_dependencies(${TEST_NAME} VkLayer_khronos_profiles ${TEST_JSON_FILES})
+    add_dependencies(${TEST_NAME} ProfilesLayer ${TEST_JSON_FILES})
     target_link_libraries(${TEST_NAME} Vulkan::Headers Vulkan::Vulkan GTest::gtest GTest::gtest_main Vulkan::LayerSettings)
     target_compile_definitions(${TEST_NAME} PUBLIC JSON_TEST_FILES_PATH="${CMAKE_SOURCE_DIR}/profiles/test/data/")
     target_compile_definitions(${TEST_NAME} PUBLIC JSON_PROFILES_PATH="${CMAKE_SOURCE_DIR}/profiles/")
 
-    target_compile_definitions(${TEST_NAME} PUBLIC TEST_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_khronos_profiles>")
+    target_compile_definitions(${TEST_NAME} PUBLIC TEST_BINARY_PATH="$<TARGET_FILE_DIR:ProfilesLayer>")
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT
-        "VK_LAYER_PATH=$<TARGET_FILE_DIR:VkLayer_khronos_profiles>"
+        "VK_LAYER_PATH=$<TARGET_FILE_DIR:ProfilesLayer>"
     )
 
     set_target_properties(${TEST_NAME} PROPERTIES FOLDER "Profiles layer/Tests")
@@ -77,7 +77,7 @@ function(LayerTestAndroid NAME)
                 vktestframework.cpp)
 
     add_test(NAME ${ANDROID_APK_NAME} COMMAND profiles_${NAME})
-    add_dependencies(${ANDROID_APK_NAME} VkLayer_khronos_profiles VpCreateDesktopBaseline2022 VpCreateDesktopPortability2022)
+    add_dependencies(${ANDROID_APK_NAME} ProfilesLayer VpCreateDesktopBaseline2022 VpCreateDesktopPortability2022)
 
     if (NOT ANDROID_SDK_HOME)
         set(ANDROID_SDK_HOME $ENV{ANDROID_SDK_HOME})
@@ -111,7 +111,7 @@ function(LayerTestAndroid NAME)
     target_compile_definitions(${ANDROID_APK_NAME} PUBLIC
                                JSON_TEST_FILES_PATH="/sdcard/Android/data/com.example.VulkanProfilesLayerTests/files/"
                                JSON_PROFILES_PATH="/sdcard/Android/data/com.example.VulkanProfilesLayerTests/files/"
-                               TEST_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_khronos_profiles>"
+                               TEST_BINARY_PATH="$<TARGET_FILE_DIR:ProfilesLayer>"
                                PROFILES_LAYER_APK VK_PROTOTYPES
                                )
     target_include_directories(${ANDROID_APK_NAME} PUBLIC
@@ -131,7 +131,7 @@ function(LayerTestAndroid NAME)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEST_FILES_JSON} ${PROJECT_BINARY_DIR}/apk/assets
         COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/apk/out
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${ANDROID_APK_NAME}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${ANDROID_APK_NAME}>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:VkLayer_khronos_profiles> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:VkLayer_khronos_profiles>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:ProfilesLayer> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:ProfilesLayer>
         COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -A ${PROJECT_BINARY_DIR}/apk/assets -F ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out
         COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk androiddebugkey
         COMMAND ${_zipalign} -f 4 ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}.apk

--- a/profiles/CMakeLists.txt
+++ b/profiles/CMakeLists.txt
@@ -101,6 +101,7 @@ add_custom_target(VpGenerated
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/schema
 	COMMAND ${CMAKE_COMMAND} -E copy_directory ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/profiles ${CMAKE_CURRENT_LIST_DIR}
 	COMMAND Python3::Interpreter ${LAYER_PYTHON_FILES}
+		--api ${API_TYPE}
 		--registry ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml
 		--input ${CMAKE_CURRENT_LIST_DIR}
 		--output-library-inc ${PROJECT_SOURCE_DIR}/library/include/vulkan

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -40,6 +40,8 @@ if (UPDATE_DEPS)
     endif()
     list(APPEND update_dep_command "--config")
     list(APPEND update_dep_command "${_build_type}")
+    list(APPEND update_dep_command "--api")
+    list(APPEND update_dep_command "${API_TYPE}")
 
     set(UPDATE_DEPS_DIR_SUFFIX "${_build_type}")
     if (ANDROID)

--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -3712,6 +3712,10 @@ class VulkanProfilesLayerGenerator():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
+    parser.add_argument('-api', action='store',
+                        default='vulkan',
+                        choices=['vulkan'],
+                        help="Target API")
     parser.add_argument('-registry', action='store', help='Use specified registry file instead of vk.xml')
     parser.add_argument('-outLayer', action='store', help='Output the layer source file')
 
@@ -3725,7 +3729,7 @@ if __name__ == '__main__':
     if args.outLayer is not None:
         outputPath = args.outLayer
 
-    registry = gen_profiles_solution.VulkanRegistry(registryPath)
+    registry = gen_profiles_solution.VulkanRegistry(registryPath, args.api)
 
     generator = VulkanProfilesLayerGenerator()
     generator.generate(outputPath, registry)

--- a/scripts/gen_profiles_solution.py
+++ b/scripts/gen_profiles_solution.py
@@ -4485,6 +4485,10 @@ class VulkanProfilesDocGenerator():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
+    parser.add_argument('--api', action='store',
+                        default='vulkan',
+                        choices=['vulkan'],
+                        help="Target API")
     parser.add_argument('--registry', '-r', action='store', required=True,
                         help='Use specified registry file instead of vk.xml')
     parser.add_argument('--input', '-i', action='store', required=True,
@@ -4529,7 +4533,7 @@ if __name__ == '__main__':
     schema = None
 
     if args.registry != None:
-        registry = VulkanRegistry(args.registry)
+        registry = VulkanRegistry(args.registry, args.api)
 
     if args.output_schema != None or args.validate:
         generator = VulkanProfilesSchemaGenerator(registry)

--- a/scripts/gen_profiles_tests.py
+++ b/scripts/gen_profiles_tests.py
@@ -770,6 +770,10 @@ class ProfileGenerator():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
+    parser.add_argument('-api', action='store',
+                        default='vulkan',
+                        choices=['vulkan'],
+                        help="Target API")
     parser.add_argument('-registry', action='store',
                         help='Use specified registry file instead of vk.xml')
     parser.add_argument('-outProfile', action='store',
@@ -783,7 +787,7 @@ if __name__ == '__main__':
         parser.print_help()
         exit()
 
-    registry = gen_profiles_solution.VulkanRegistry(args.registry)
+    registry = gen_profiles_solution.VulkanRegistry(args.registry, args.api)
     generator = ProfileGenerator()
     generator.generate_profile(args.outProfile, registry)
     generator.generate_tests(args.outTests, registry)


### PR DESCRIPTION
This introduces similar parameterization of the used API type and layer name as we've done for the validation layers thus I hope it is non-controversial and seen as a general improvement overall.