### PR TITLE
Prevent duplicate CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,12 @@ env:
   CMAKE_GENERATOR: Ninja
 
 on:
-    push:
-    pull_request:
-        branches:
-            - main
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently if a user doesn't developer in a fork they run twice the amount of CI.

This fixes that issue.

See:
https://github.com/orgs/community/discussions/26276