### PR TITLE
tests: Added portability enumeration flag to instance creation

### DIFF
--- a/layer/tests/profiles_test_helper.cpp
+++ b/layer/tests/profiles_test_helper.cpp
@@ -102,8 +102,15 @@ VkResult profiles_test::VulkanInstanceBuilder::init(uint32_t apiVersion, const s
 
     VkApplicationInfo app_info{GetDefaultApplicationInfo()};
     app_info.apiVersion = apiVersion;
+    
 
     VkInstanceCreateInfo inst_create_info = {};
+
+#ifdef __APPLE__
+    _extension_names.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+    inst_create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#endif
+
     inst_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     inst_create_info.pApplicationInfo = &app_info;
     inst_create_info.pNext = nullptr;


### PR DESCRIPTION
14 unit tests were failing on macOS because the instance creation code did not enable the portability enumeration flag.

Now, these tests are still failing, but for other reasons (some crash). Many look like they are assuming some features are available on macOS which aren't. I can try and sort through these, but the profiles code is complex. If @christophe-lunarg could please take a look on his mac by running the tests after this fix is merged, and perhaps some of them are 'easy' to fix with his pre-existing knowledge of the profiles test code ;-)