### PR TITLE
Fix logging on Android to correctly print formatted input values

### DIFF
--- a/layer/profiles_settings.cpp
+++ b/layer/profiles_settings.cpp
@@ -125,7 +125,7 @@ void LogMessage(ProfileLayerSettings *layer_settings, DebugReportBits report, co
 
     if (layer_settings->log.debug_actions & DEBUG_ACTION_STDOUT_BIT) {
 #if defined(__ANDROID__)
-        AndroidPrintf(report, message);
+        AndroidPrintf(report, log);
 #else
         fprintf(stdout, "%s", log);
 #endif


### PR DESCRIPTION
Fixes Android logs to print the input values given, rather than printing the formatting specifiers (e.g. '%s') in the message.