### PR TITLE
Update VPA15 description

### DIFF
--- a/profiles/VP_ANDROID_15_minimums.json
+++ b/profiles/VP_ANDROID_15_minimums.json
@@ -140,7 +140,7 @@
             "version": 1,
             "api-version": "1.3.273",
             "label": "Vulkan Minimum Requirements for Android 15",
-            "description": "Collection of functionality that is mandated for Android 15",
+            "description": "Collection of functionality that is mandated for chipsets that launch (or renew Google Requirements Freeze) on Android 15",
             "contributors": {
                 "Trevor David Black": {
                     "company": "Google",
@@ -156,7 +156,7 @@
             "history": [
                 {
                     "revision": 1,
-                    "date": "2023-12-08",
+                    "date": "2023-12-15",
                     "author": "Ian Elliott",
                     "comment": "First version"
                  }


### PR DESCRIPTION
Because the published VPA15 is for software developers (to use to filter devices to use Vulkan with) and not simply for hardware developers.