### PR TITLE
sdk: fix install of gen_profiles_file.py

### DIFF
--- a/profiles/CMakeLists.txt
+++ b/profiles/CMakeLists.txt
@@ -211,7 +211,7 @@ install(
 
 install(
     FILES
-        ${MERGE_PYTHON_FILES}
+        ${MERGE_SCRIPT}
         ${SOLUTION_SCRIPT}
         ${PROJECT_SOURCE_DIR}/schema/${PROFILES_SCHEMA_FILENAME}
     DESTINATION


### PR DESCRIPTION
This was discovered during SDK integration builds.

Commit 3e32c809696dcbe81c31c1d04fc2ca62d1f584aa broke installation of the gen_profiles_file.py script, because it renamed MERGE_PYTHON_FILES and LAYER_PYTHON_FILES to MERGE_SCRIPT and SOLUTION_SCRIPT, respectively, in CMakeLists.txt:

    -set(MERGE_PYTHON_FILES ${PROJECT_SOURCE_DIR}/scripts/gen_profiles_file.py)
    -set(LAYER_PYTHON_FILES ${PROJECT_SOURCE_DIR}/scripts/gen_profiles_solution.py)
    +set(MERGE_SCRIPT ${PROJECT_SOURCE_DIR}/scripts/gen_profiles_file.py)
    +set(SOLUTION_SCRIPT ${PROJECT_SOURCE_DIR}/scripts/gen_profiles_solution.py)

but neglected to change the MERGE_PYTHON_FILES reference in profiles/CMakeLists.txt, where the install target is defined (note that SOLUTION_SCRIPT was correctly changed):

     install(
         FILES
             ${MERGE_PYTHON_FILES}
    -        ${LAYER_PYTHON_FILES}
    +        ${SOLUTION_SCRIPT}
             ${PROJECT_SOURCE_DIR}/schema/${PROFILES_SCHEMA_FILENAME}
         DESTINATION
             "${CMAKE_INSTALL_DATADIR}/vulkan/registry"
      )

This change changes MERGE_PYTHON_FILES in profiles/CMakeLists.txt to MERGE_SCRIPT, as was apparently intended.