### PR TITLE
profiles: Ignore host image copy structs in pNext chains

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -2939,6 +2939,7 @@ class VulkanProfilesLayerGenerator():
     emulated_extensions = ['VK_KHR_portability_subset']
     additional_features = ['VkPhysicalDeviceFeatures', 'VkPhysicalDevicePortabilitySubsetFeaturesKHR']
     additional_properties = ['VkPhysicalDeviceProperties', 'VkPhysicalDeviceLimits', 'VkPhysicalDeviceSparseProperties', 'VkPhysicalDeviceToolProperties', 'VkPhysicalDevicePortabilitySubsetPropertiesKHR']
+    ignored_structs = ['VkPhysicalDeviceHostImageCopyPropertiesEXT', 'VkPhysicalDeviceHostImageCopyFeaturesEXT']
 
     def generate(self, path, registry):
         self.registry = registry
@@ -3175,7 +3176,7 @@ class VulkanProfilesLayerGenerator():
         first = True
         count = 0
         for name, value  in registry.structs.items():
-            if name == 'VkPhysicalDeviceHostImageCopyPropertiesEXT' or name == 'VkPhysicalDeviceHostImageCopyFeaturesEXT':
+            if name in self.ignored_structs:
                 continue
             if (extends in value.extends and value.isAlias == False) or (name in additional):
                 aliases = value.aliases.copy()
@@ -3561,6 +3562,9 @@ class VulkanProfilesLayerGenerator():
 
     def generate_fill_case(self, struct):
         structure = registry.structs[struct]
+        if structure.name in self.ignored_structs:
+            print(structure.name)
+            return ''
         gen = '            case ' + structure.sType + ':\n'
         gen += '                '
         if structure.definedByExtensions:


### PR DESCRIPTION
Ignore host image copy structs when filling pNext chains of query functions