### PR TITLE
profiles: Don't ignore VkPhysicalDeviceHostImageCopyFeaturesEXT

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -46,7 +46,7 @@ COPYRIGHT_HEADER = '''
  * - Mike Weiblen
  * - Arda Coskunses
  * - Jeremy Kniager
- 
+
  * This file is ***GENERATED***.  Do Not Edit.
  * See scripts/gen_profiles_layer.py for modifications.
  */
@@ -651,7 +651,7 @@ GET_VALUE_FUNCTIONS = '''
         return valid;
     }
 
-    bool GetValue(const char* device_name, const Json::Value &parent, const std::string &member, const char *name, int32_t *dest, bool not_modifiable, bool requested_profile, 
+    bool GetValue(const char* device_name, const Json::Value &parent, const std::string &member, const char *name, int32_t *dest, bool not_modifiable, bool requested_profile,
                   std::function<bool(ProfileLayerSettings *, bool, const char *, const char *, int32_t, int32_t, bool)> warn_func = nullptr) {
         if (member != name) {
             return true;
@@ -1629,7 +1629,7 @@ VkResult JsonLoader::LoadFile(const std::string& filename) {
     }
 
     LogMessage(&layer_settings, DEBUG_REPORT_NOTIFICATION_BIT, "Loading \\"%s\\"\\n", filename.c_str());
-    
+
     if (layer_settings.simulate.profile_validation) {
         JsonValidator validator;
         if (!validator.Init()) {
@@ -2939,7 +2939,9 @@ class VulkanProfilesLayerGenerator():
     emulated_extensions = ['VK_KHR_portability_subset']
     additional_features = ['VkPhysicalDeviceFeatures', 'VkPhysicalDevicePortabilitySubsetFeaturesKHR']
     additional_properties = ['VkPhysicalDeviceProperties', 'VkPhysicalDeviceLimits', 'VkPhysicalDeviceSparseProperties', 'VkPhysicalDeviceToolProperties', 'VkPhysicalDevicePortabilitySubsetPropertiesKHR']
-    ignored_structs = ['VkPhysicalDeviceHostImageCopyPropertiesEXT', 'VkPhysicalDeviceHostImageCopyFeaturesEXT']
+    # VkPhysicalDeviceHostImageCopyFeaturesEXT is not ignored to allow the people using the MockICD to still have the feature enabled,
+    # but use the properties in the MockICD until HostImageCopyPropertiesEXT is fixed.
+    ignored_structs = ['VkPhysicalDeviceHostImageCopyPropertiesEXT']
 
     def generate(self, path, registry):
         self.registry = registry


### PR DESCRIPTION
follow-up for https://github.com/KhronosGroup/Vulkan-Profiles/pull/663

the issue with ignoring `VkPhysicalDeviceHostImageCopyFeaturesEXT` is no one using the profiles layer can expose support for it

The main use case here is we (VVL) have the feature and properties passed back up, but now the `hostImageCopy` gets saved but since there is not switch case it is not set