### PR TITLE
layer: Fix checking device supported extensions

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -3534,8 +3534,17 @@ class VulkanProfilesLayerGenerator():
     def generate_physical_device_chain_case(self, ext, version, property_names, feature_names):
         gen = self.generate_platform_protect_begin(ext)
         if ext:
-            ext_name = registry.extensions[ext].upperCaseName
-            gen += '\n                if (PhysicalDeviceData::HasExtension(&pdd, ' + ext_name + '_EXTENSION_NAME)) {\n'
+            gen += '\n                if ('
+            first = True
+            for promotedTo in [ext] + registry.getExtensionPromotedToExtensionList(ext):
+                if first:
+                    first = False
+                else:
+                    gen += ' || '
+                gen += 'PhysicalDeviceData::HasExtension(&pdd, '
+                gen += registry.extensions[promotedTo].upperCaseName + '_EXTENSION_NAME'
+                gen += ')'
+            gen += ') {\n'
         else:
             gen += '\n                if (api_version_above_' + str(version.major) + '_' + str(version.minor) + ') {\n'
         for property_name in property_names:


### PR DESCRIPTION
Fix checking which extension the device supports. Currently only the original extension was checked and not any of the promoted to extensions. This was an issue with a corner case when a device would support a promoted extension but not the original one.

For example a device could support `VK_EXT_mutable_descriptor_type`, but not `VK_VALVE_mutable_descriptor_type`.