### PR TITLE
tests: Update android targetSdkVersion from 26 to 33

### DIFF
--- a/layer/tests/CMakeLists.txt
+++ b/layer/tests/CMakeLists.txt
@@ -148,8 +148,8 @@ function(LayerTestAndroid NAME)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${ANDROID_APK_NAME}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${ANDROID_APK_NAME}>
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:ProfilesLayer> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:ProfilesLayer>
         COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -A ${PROJECT_BINARY_DIR}/apk/assets -F ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out
-        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk androiddebugkey
         COMMAND ${_zipalign} -f 4 ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}.apk
+        COMMAND apksigner sign --verbose --ks $ENV{HOME}/.android/debug.keystore --ks-pass pass:android ${PROJECT_BINARY_DIR}/apk/out/${ANDROID_APK_NAME}.apk
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "${run_environment}")

--- a/layer/tests/platforms/android/AndroidManifest.xml
+++ b/layer/tests/platforms/android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.VulkanProfilesLayerTests" android:versionCode="1" android:versionName="1.0">
 
     <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="26"/>
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="33"/>
 
     <!-- This .apk has no Java code itself, so set hasCode to false. -->
     <application android:hasCode="false" android:debuggable='true'>

--- a/library/test/CMakeLists.txt
+++ b/library/test/CMakeLists.txt
@@ -139,8 +139,8 @@ function (create_android_package NAME)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${apk_test_target}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${apk_test_target}>
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${NAME}> ${PROJECT_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${NAME}>
         COMMAND ${_aapt} package -f -M ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml -I ${_android_jar} -F ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out
-        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk androiddebugkey
         COMMAND ${_zipalign} -f 4 ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}-unaligned.apk ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}.apk
+        COMMAND apksigner sign --verbose --ks $ENV{HOME}/.android/debug.keystore --ks-pass pass:android ${PROJECT_BINARY_DIR}/apk/out/${apk_test_target}.apk
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 endfunction(create_android_package)
 

--- a/library/test/platforms/android/AndroidManifest.xml
+++ b/library/test/platforms/android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.VpLibrary_test_api_create_device_android" android:versionCode="1" android:versionName="1.0">
 
     <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="26"/>
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="33"/>
 
     <!-- This .apk has no Java code itself, so set hasCode to false. -->
     <application android:hasCode="false" android:debuggable='true'>


### PR DESCRIPTION
There's an issue with Android 14 that will cause a prompt to display on the phone  when trying to run tests. This can cause an issue with CI as the prompt needs to be hit before the tests begin to run. The prompt displays:
```
This app was built for an older version of Android. It might not work
properly and doesn't include the latest security and privacy
protections.  Check for an update, or contact the app's developer
```

Also, apksigner will be used instead of jarsigner. apksigner has since replaced jarsigner. Builing for for newer version of android will produce  this error when trying to use jarsigner:
```
ERROR: unexpected exception:
_run(/home/lunarg/Android/Sdk/platform-tools/adb -s R5CX21HV9TJ
install -r -g -t
/home/lunarg/.jenkins/workspace/manual-VulkanProfiles/VulkanProfiles/android-build/apk/out/VulkanProfilesLayerTests.apk)
return 1, stdout=Performing Streamed Install, stderr=adb: failed to
install
/home/lunarg/.jenkins/workspace/manual-VulkanProfiles/VulkanProfiles/android-build/apk/out/VulkanProfilesLayerTests.apk:
Failure [INSTALL_PARSE_FAILED_NO_CERTIFICATES: Scanning Failed.: No
signature found in package of version 2 or newer for package
com.example.VulkanProfilesLayerTests]
```

Similar issue on VVL and gfxreconstruct:
- https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8045
- https://github.com/LunarG/gfxreconstruct/pull/1079

layer/tests/platforms/android/AndroidManifest.xml: library/test/platforms/android/AndroidManifest.xml:
- update the android:targetSdkVersion from 26 to 33

layer/tests/CMakeLists.txt:
library/test/CMakeLists.txt
- update to use apksigner instead of jarsigner