### PR TITLE
Add Android 16 profile

### DIFF
--- a/profiles/VP_ANDROID_16_minimums.json
+++ b/profiles/VP_ANDROID_16_minimums.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.2-290.json#",
+    "capabilities": {
+        "MUST": {
+            "extensions": {
+                "VK_KHR_8bit_storage": 1,
+                "VK_KHR_global_priority": 1,
+                "VK_KHR_load_store_op_none": 1,
+                "VK_KHR_maintenance6": 1,
+                "VK_KHR_map_memory2": 1,
+                "VK_KHR_push_descriptor": 1,
+                "VK_KHR_shader_expect_assume": 1,
+                "VK_KHR_shader_float_controls2": 1,
+                "VK_KHR_shader_maximal_reconvergence": 1,
+                "VK_KHR_shader_subgroup_rotate": 1,
+                "VK_KHR_shader_subgroup_uniform_control_flow": 1,
+                "VK_KHR_swapchain_mutable_format": 1,
+                "VK_EXT_host_image_copy": 1,
+                "VK_EXT_image_2d_view_of_3d": 1,
+                "VK_EXT_pipeline_protected_access": 1,
+                "VK_EXT_pipeline_robustness": 1,
+                "VK_EXT_transform_feedback": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "depthClamp": true,
+                    "fullDrawIndexUint32": true,
+                    "shaderInt16": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "descriptorIndexing": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "samplerMirrorClampToEdge": true,
+                    "scalarBlockLayout": true,
+                    "runtimeDescriptorArray": true
+                },
+                "VkPhysicalDeviceProtectedMemoryFeatures": {
+                    "protectedMemory": true
+                },
+                "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+                    "shaderIntegerDotProduct": true
+                },
+                "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                    "transformFeedback": true
+                },
+                "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                    "image2DViewOf3D": true
+                },
+                "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                    "shaderSubgroupUniformControlFlow": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "bufferImageGranularity": 4096,
+                        "lineWidthGranularity": 0.5,
+                        "maxBoundDescriptorSets": 7,
+                        "maxColorAttachments": 8,
+                        "maxComputeWorkGroupInvocations": 256,
+                        "maxComputeWorkGroupSize": [ 256, 256, 64 ],
+                        "maxImageArrayLayers": 2048,
+                        "maxImageDimension1D": 8192,
+                        "maxImageDimension2D": 8192,
+                        "maxImageDimensionCube": 8192,
+                        "maxDescriptorSetStorageBuffers": 96,
+                        "maxDescriptorSetStorageImages": 144,
+                        "maxDescriptorSetUniformBuffers": 90,
+                        "maxFragmentCombinedOutputResources": 16,
+                        "maxPerStageDescriptorUniformBuffers": 15,
+                        "maxPerStageResources": 200,
+                        "maxPushConstantsSize": 256,
+                        "maxSamplerLodBias": 14,
+                        "maxUniformBufferRange": 65536,
+                        "maxVertexOutputComponents": 128,
+                        "mipmapPrecisionBits": 6,
+                        "pointSizeGranularity": 0.125,
+                        "standardSampleLocations": true,
+                        "subTexelPrecisionBits": 8,
+                        "timestampComputeAndGraphics": true
+                    }
+                },
+                "VkPhysicalDeviceFloatControlsProperties": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true
+                },
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "subgroupSupportedStages": ["VK_SHADER_STAGE_FRAGMENT_BIT", "VK_SHADER_STAGE_COMPUTE_BIT"]
+                }
+            }
+        },
+        "multisampledToSingleSampled": {
+            "extensions": {
+                "VK_EXT_multisampled_render_to_single_sampled": 1
+            }
+        },
+        "shaderStencilExport": {
+            "extensions": {
+                "VK_EXT_shader_stencil_export": 1
+            }
+        }
+    },
+    "profiles": {
+        "VP_ANDROID_16_minimums": {
+            "version": 1,
+            "api-version": "1.3.273",
+            "label": "Vulkan Minimum Requirements for Android 16",
+            "description": "Collection of functionality that is mandated on Android 16",
+            "contributors": {
+                "Ian Elliott": {
+                    "company": "Google",
+                    "email": "ianelliott@google.com",
+                    "contact": true
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2024-02-20",
+                    "author": "Ian Elliott",
+                    "comment": "First draft"
+                },
+                {
+                    "revision": 2,
+                    "date": "2024-07-22",
+                    "author": "Ian Elliott",
+                    "comment": "Added proposed Vulkan 1.4 scope"
+                }
+            ],
+            "profiles": [
+                "VP_ANDROID_15_minimums"
+             ],
+             "capabilities": [
+                "MUST",
+                ["multisampledToSingleSampled", "shaderStencilExport"]
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This is the "Vulkan Profile for Android 16" (a.k.a. VPA16).  It will be required for chipsets starting or restarting Google Requirements Freeze with Android 16.  It depends on VPA15, which in turn depends on ABP 2022.