### PR TITLE
Add Android 16 profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install jsonschema
         run: python3 -m pip install jsonschema
       - name: Setup ccache
@@ -92,10 +92,9 @@ jobs:
           -D CMAKE_ANDROID_STL_TYPE=c++_static \
           -D CMAKE_ANDROID_RTTI=YES \
           -D CMAKE_ANDROID_EXCEPTIONS=YES \
-          -D ANDROID_BUILD_TOOLS=34.0.0 \
           -D ANDROID_USE_LEGACY_TOOLCHAIN_FILE=NO \
           -D BUILD_WERROR=ON \
-          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_BUILD_TYPE=Debug \
           -D UPDATE_DEPS=ON \
           -D BUILD_TESTS=OFF
       - name: Build

--- a/profiles/CMakeLists.txt
+++ b/profiles/CMakeLists.txt
@@ -12,10 +12,11 @@ set(PROFILES_FILES_FOR_INSTALL
     VP_ANDROID_baseline_2021.json
     VP_ANDROID_baseline_2022.json
     VP_ANDROID_15_minimums.json
+    VP_ANDROID_16_minimums.json
 )
 
 set(PROFILES_FILES_FOR_API_LIBRARY
-    "VP_KHR_roadmap.json,VP_LUNARG_minimum_requirements.json,VP_ANDROID_baseline_2021.json,VP_ANDROID_baseline_2022.json,VP_ANDROID_15_minimums.json"
+    "VP_KHR_roadmap.json,VP_LUNARG_minimum_requirements.json,VP_ANDROID_baseline_2021.json,VP_ANDROID_baseline_2022.json,VP_ANDROID_15_minimums.json,VP_ANDROID_16_minimums.json"
 )
 
 set(PROFILES_FILES_FOR_VULKAN_HEADER_DOC
@@ -23,7 +24,7 @@ set(PROFILES_FILES_FOR_VULKAN_HEADER_DOC
 )
 
 set(PROFILES_FILES_FOR_ANDROID_DOC
-    "VP_ANDROID_15_minimums.json,VP_ANDROID_baseline_2022.json,VP_ANDROID_baseline_2021.json,VP_LUNARG_minimum_requirements.json"
+    "VP_ANDROID_16_minimums.json,VP_ANDROID_15_minimums.json,VP_ANDROID_baseline_2022.json,VP_ANDROID_baseline_2021.json,VP_LUNARG_minimum_requirements.json"
 )
 
 set(PROFILE_DESKTOP_MAX_2024_LABEL "LunarG Vulkan Desktop Max 2024 profile")

--- a/profiles/VP_ANDROID_16_minimums.json
+++ b/profiles/VP_ANDROID_16_minimums.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.2-276.json#",
+    "capabilities": {
+        "MUST": {
+            "extensions": {
+                "VK_KHR_8bit_storage": 1,
+                "VK_KHR_global_priority": 1,
+                "VK_KHR_load_store_op_none": 1,
+                "VK_KHR_maintenance6": 1,
+                "VK_KHR_map_memory2": 1,
+                "VK_KHR_push_descriptor": 1,
+                "VK_KHR_shader_expect_assume": 1,
+                "VK_KHR_shader_float_controls2": 1,
+                "VK_KHR_shader_maximal_reconvergence": 1,
+                "VK_KHR_shader_subgroup_rotate": 1,
+                "VK_KHR_shader_subgroup_uniform_control_flow": 1,
+                "VK_KHR_swapchain_mutable_format": 1,
+                "VK_EXT_host_image_copy": 1,
+                "VK_EXT_image_2d_view_of_3d": 1,
+                "VK_EXT_pipeline_protected_access": 1,
+                "VK_EXT_pipeline_robustness": 1,
+                "VK_EXT_transform_feedback": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "depthClamp": true,
+                    "fullDrawIndexUint32": true,
+                    "shaderInt16": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "descriptorIndexing": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "samplerMirrorClampToEdge": true,
+                    "scalarBlockLayout": true,
+                    "runtimeDescriptorArray": true
+                },
+                "VkPhysicalDeviceProtectedMemoryFeatures": {
+                    "protectedMemory": true
+                },
+                "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+                    "shaderIntegerDotProduct": true
+                },
+                "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                    "transformFeedback": true
+                },
+                "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                    "image2DViewOf3D": true
+                },
+                "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                    "shaderSubgroupUniformControlFlow": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "bufferImageGranularity": 4096,
+                        "lineWidthGranularity": 0.5,
+                        "maxBoundDescriptorSets": 7,
+                        "maxColorAttachments": 8,
+                        "maxComputeWorkGroupInvocations": 256,
+                        "maxComputeWorkGroupSize": [ 256, 256, 64 ],
+                        "maxImageArrayLayers": 2048,
+                        "maxImageDimension1D": 8192,
+                        "maxImageDimension2D": 8192,
+                        "maxImageDimensionCube": 8192,
+                        "maxDescriptorSetStorageBuffers": 96,
+                        "maxDescriptorSetStorageImages": 144,
+                        "maxDescriptorSetUniformBuffers": 90,
+                        "maxFragmentCombinedOutputResources": 16,
+                        "maxPerStageDescriptorUniformBuffers": 15,
+                        "maxPerStageResources": 200,
+                        "maxPushConstantsSize": 256,
+                        "maxSamplerLodBias": 14,
+                        "maxUniformBufferRange": 65536,
+                        "maxVertexOutputComponents": 128,
+                        "mipmapPrecisionBits": 6,
+                        "pointSizeGranularity": 0.125,
+                        "standardSampleLocations": true,
+                        "subTexelPrecisionBits": 8,
+                        "timestampComputeAndGraphics": true
+                    }
+                },
+                "VkPhysicalDeviceFloatControlsProperties": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true
+                },
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "subgroupSupportedStages": ["VK_SHADER_STAGE_FRAGMENT_BIT", "VK_SHADER_STAGE_COMPUTE_BIT"]
+                }
+            }
+        },
+        "multisampledToSingleSampled": {
+            "extensions": {
+                "VK_EXT_multisampled_render_to_single_sampled": 1
+            }
+        },
+        "shaderStencilExport": {
+            "extensions": {
+                "VK_EXT_shader_stencil_export": 1
+            }
+        }
+    },
+    "profiles": {
+        "VP_ANDROID_16_minimums": {
+            "version": 1,
+            "api-version": "1.3.276",
+            "label": "Vulkan Minimum Requirements for Android 16",
+            "description": "Collection of functionality that is mandated on Android 16",
+            "contributors": {
+                "Ian Elliott": {
+                    "company": "Google",
+                    "email": "ianelliott@google.com",
+                    "contact": true
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2024-02-20",
+                    "author": "Ian Elliott",
+                    "comment": "First draft"
+                },
+                {
+                    "revision": 2,
+                    "date": "2024-07-22",
+                    "author": "Ian Elliott",
+                    "comment": "Added proposed future Vulkan scope"
+                }
+            ],
+            "profiles": [
+                "VP_ANDROID_15_minimums"
+             ],
+             "capabilities": [
+                "MUST",
+                ["multisampledToSingleSampled", "shaderStencilExport"]
+            ]
+        }
+    }
+}

--- a/profiles/test/test_validate.cpp
+++ b/profiles/test/test_validate.cpp
@@ -286,3 +286,11 @@ TEST(test_validate, VP_ANDROID_15_minimums) {
     const Json::Value json_document3 = ParseJsonFile(path.c_str());
     EXPECT_TRUE(validator.Check(json_document3));
 }
+
+TEST(test_validate, VP_ANDROID_16_minimums) {
+    JsonValidator validator;
+
+    const std::string path = std::string(PROFILE_FILES_PATH) + "VP_ANDROID_16_minimums.json";
+    const Json::Value json_document3 = ParseJsonFile(path.c_str());
+    EXPECT_TRUE(validator.Check(json_document3));
+}


### PR DESCRIPTION
This is the "Vulkan Profile for Android 16" (a.k.a. VPA16). It will be required for chipsets starting or restarting Google Requirements Freeze with Android 16. It depends on VPA15, which in turn depends on ABP 2022.