### PR TITLE
profiles: Add video profiles support

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -136,6 +136,7 @@ Each entry in `capabilities` includes a reference name and a dictionary containi
 * `properties` - Optional. List of all required properties.
 * `formats` - Optional. List of all required formats.
 * `queueFamiliesProperties` - Optional. List of all queue families properties.
+* `videoProfiles` - Optional. List of all required video profilies.
 
 Each entry in `profiles` includes a reference name and a dictionary containing the following sections:
 * `version` - Required. The revision of the profile.

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -144,7 +144,8 @@ add_custom_target(VpLayer_generate ALL
         --out-layer ${CMAKE_SOURCE_DIR}/layer/profiles_generated.cpp
     VERBATIM
     SOURCES ${LAYER_PYTHON_SCRIPT}
-    DEPENDS ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml)
+    DEPENDS ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml
+            ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/video.xml)
 set_target_properties(VpLayer_generate PROPERTIES FOLDER "Profiles layer")
 add_dependencies(ProfilesLayer VpLayer_generate)
 

--- a/layer/VkLayer_khronos_profiles.json.in
+++ b/layer/VkLayer_khronos_profiles.json.in
@@ -330,6 +330,16 @@
                             "key": "SIMULATE_FORMATS_BIT",
                             "label": "Formats",
                             "description": "The Vulkan device will report the formats from the selected Profile."
+                        },
+                        {
+                            "key": "SIMULATE_VIDEO_CAPABILITIES_BIT",
+                            "label": "Video Capabilities",
+                            "description": "The Vulkan device will report video capabilities from the selected Profile."
+                        },
+                        {
+                            "key": "SIMULATE_VIDEO_FORMATS_BIT",
+                            "label": "Video Formats",
+                            "description": "The Vulkan device will report video formats from the selected Profile."
                         }
                     ],
                     "default": [ "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT" ]

--- a/layer/profiles_settings.h
+++ b/layer/profiles_settings.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2022-2023 Valve Corporation
  * Copyright (C) 2022-2023 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +32,8 @@ enum SimulateCapabilityBits {
     SIMULATE_EXTENSIONS_BIT = 1 << 3,
     SIMULATE_FORMATS_BIT = 1 << 4,
     SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT = 1 << 5,
+    SIMULATE_VIDEO_CAPABILITIES_BIT = 1 << 6,
+    SIMULATE_VIDEO_FORMATS_BIT = 1 << 7,
     SIMULATE_MAX_ENUM = 0x7FFFFFFF
 };
 typedef int SimulateCapabilityFlags;

--- a/layer/tests/CMakeLists.txt
+++ b/layer/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # ~~~
 # Copyright (c) 2021-2024 Valve Corporation
 # Copyright (c) 2021-2024 LunarG, Inc.
+# Copyright (c) 2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +46,7 @@ else()
         tests_mechanism_api_version
         tests_mechanism_check_values
         tests_mechanism_physical_device_selection
+        tests_mechanism_video_profiles
         tests_combine_union
         tests_combine_intersection
         tests_util

--- a/layer/tests/tests_combine_intersection.cpp
+++ b/layer/tests/tests_combine_intersection.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2021-2024 Valve Corporation
  * Copyright (C) 2021-2024 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +41,8 @@ class TestsIntersection : public VkTestFramework {
         const char* profile_name_data = "VP_LUNARG_test_combine_intersect"; 
         VkBool32 emulate_portability_data = VK_TRUE;
         const std::vector<const char*> simulate_capabilities = {
-            "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT", "SIMULATE_EXTENSIONS_BIT", "SIMULATE_FORMATS_BIT", "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT"};
+            "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT", "SIMULATE_EXTENSIONS_BIT", "SIMULATE_FORMATS_BIT",
+            "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT", "SIMULATE_VIDEO_CAPABILITIES_BIT", "SIMULATE_VIDEO_FORMATS_BIT"};
         const std::vector<const char*> debug_reports = {
             "DEBUG_REPORT_ERROR_BIT", "DEBUG_REPORT_WARNING_BIT", "DEBUG_REPORT_NOTIFICATION_BIT", "DEBUG_REPORT_DEBUG_BIT"};
 

--- a/layer/tests/tests_combine_union.cpp
+++ b/layer/tests/tests_combine_union.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2021-2024 Valve Corporation
  * Copyright (C) 2021-2024 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +41,8 @@ class TestsUnion : public VkTestFramework {
         const char* profile_name_data = "VP_LUNARG_test_combine_union";
         VkBool32 emulate_portability_data = VK_TRUE;
         const std::vector<const char*> simulate_capabilities = {
-            "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT",  "SIMULATE_EXTENSIONS_BIT", "SIMULATE_FORMATS_BIT", "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT"};
+            "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT",  "SIMULATE_EXTENSIONS_BIT",
+            "SIMULATE_FORMATS_BIT", "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT", "SIMULATE_VIDEO_CAPABILITIES_BIT", "SIMULATE_VIDEO_FORMATS_BIT"};
         const std::vector<const char*> debug_reports = {
             "DEBUG_REPORT_ERROR_BIT", "DEBUG_REPORT_WARNING_BIT", "DEBUG_REPORT_NOTIFICATION_BIT", "DEBUG_REPORT_DEBUG_BIT"};
 

--- a/layer/tests/tests_mechanism_video_profiles.cpp
+++ b/layer/tests/tests_mechanism_video_profiles.cpp
@@ -1,0 +1,1519 @@
+/*
+ * Copyright (C) 2021-2024 Valve Corporation
+ * Copyright (C) 2021-2024 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Daniel Rakos <daniel.rakos@rastergrid.com>
+ */
+
+#include <vulkan/vulkan_core.h>
+#include <vulkan/vulkan_beta.h>
+
+#include <gtest/gtest.h>
+#include "profiles_test_helper.h"
+
+#include <cstdarg>
+
+static VkPhysicalDevice gpu = VK_NULL_HANDLE;
+static profiles_test::VulkanInstanceBuilder inst_builder;
+static PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR pfnGetPhysicalDeviceVideoCapabilitiesKHR;
+static PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR pfnGetPhysicalDeviceVideoFormatPropertiesKHR;
+
+class TestsMechanismVideoProfiles : public VkTestFramework {
+   public:
+    TestsMechanismVideoProfiles() {}
+
+    ~TestsMechanismVideoProfiles() {}
+
+    static void SetUpTestSuite() {
+        VkResult err = VK_SUCCESS;
+
+        const char* profile_file_data = JSON_TEST_FILES_PATH "VP_RASTERGRID_test_video_profiles.json";
+        const char* profile_name_data = "VP_RASTERGRID_test_video_profiles";
+        VkBool32 emulate_portability_data = VK_TRUE;
+        const char* simulate_capabilities = "SIMULATE_MAX_ENUM";
+
+        std::vector<VkLayerSettingEXT> settings = {
+            {kLayerName, kLayerSettingsProfileFile, VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &profile_file_data},
+            {kLayerName, kLayerSettingsProfileName, VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &profile_name_data},
+            {kLayerName, kLayerSettingsEmulatePortability, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &emulate_portability_data},
+            {kLayerName, kLayerSettingsSimulateCapabilities, VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &simulate_capabilities}};
+
+        err = inst_builder.init(settings);
+        ASSERT_EQ(err, VK_SUCCESS);
+
+        err = inst_builder.getPhysicalDevice(profiles_test::MODE_PROFILE, &gpu);
+        ASSERT_EQ(err, VK_SUCCESS);
+
+        pfnGetPhysicalDeviceVideoCapabilitiesKHR =
+            reinterpret_cast<PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR>(vkGetInstanceProcAddr(
+                inst_builder.getInstance(profiles_test::MODE_PROFILE), "vkGetPhysicalDeviceVideoCapabilitiesKHR"));
+        ASSERT_NE(pfnGetPhysicalDeviceVideoCapabilitiesKHR, nullptr);
+
+        pfnGetPhysicalDeviceVideoFormatPropertiesKHR =
+            reinterpret_cast<PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR>(vkGetInstanceProcAddr(
+                inst_builder.getInstance(profiles_test::MODE_PROFILE), "vkGetPhysicalDeviceVideoFormatPropertiesKHR"));
+        ASSERT_NE(pfnGetPhysicalDeviceVideoFormatPropertiesKHR, nullptr);
+    }
+
+    const VkVideoProfileInfoKHR* GetDecodeH264BaselineProfile() const {
+        static const VkVideoDecodeH264ProfileInfoKHR decode_h264_baseline = {VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR,
+                                                                             nullptr, STD_VIDEO_H264_PROFILE_IDC_BASELINE,
+                                                                             VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR};
+        static const VkVideoProfileInfoKHR decode_h264 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &decode_h264_baseline,
+            VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,       VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR};
+        return &decode_h264;
+    }
+
+    const VkVideoProfileInfoKHR* GetDecodeH264MainProfile() const {
+        static const VkVideoDecodeH264ProfileInfoKHR decode_h264_main = {
+            VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR, nullptr, STD_VIDEO_H264_PROFILE_IDC_MAIN,
+            VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_KHR};
+        static const VkVideoProfileInfoKHR decode_h264 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &decode_h264_main,
+            VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,       VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR};
+        return &decode_h264;
+    }
+
+    const VkVideoProfileInfoKHR* GetDecodeH265MainProfile() const {
+        static const VkVideoDecodeH265ProfileInfoKHR decode_h265_main = {VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR,
+                                                                         nullptr, STD_VIDEO_H265_PROFILE_IDC_MAIN};
+        static const VkVideoProfileInfoKHR decode_h265 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &decode_h265_main,
+            VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,       VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR};
+        return &decode_h265;
+    }
+
+    const VkVideoProfileInfoKHR* GetDecodeH265Main10Profile() const {
+        static const VkVideoDecodeH265ProfileInfoKHR decode_h265_main_10 = {VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR,
+                                                                            nullptr, STD_VIDEO_H265_PROFILE_IDC_MAIN_10};
+        static const VkVideoProfileInfoKHR decode_h265 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &decode_h265_main_10,
+            VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR,      VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR};
+        return &decode_h265;
+    }
+
+    const VkVideoProfileInfoKHR* GetEncodeH264BaselineProfile() const {
+        static const VkVideoEncodeH264ProfileInfoKHR encode_h264_baseline = {VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR,
+                                                                             nullptr, STD_VIDEO_H264_PROFILE_IDC_BASELINE};
+        static const VkVideoProfileInfoKHR encode_h264 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &encode_h264_baseline,
+            VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,       VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR};
+        return &encode_h264;
+    }
+
+    const VkVideoProfileInfoKHR* GetEncodeH264MainProfile() const {
+        static const VkVideoEncodeH264ProfileInfoKHR encode_h264_main = {VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR,
+                                                                         nullptr, STD_VIDEO_H264_PROFILE_IDC_MAIN};
+        static const VkVideoProfileInfoKHR encode_h264 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &encode_h264_main,
+            VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,       VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR};
+        return &encode_h264;
+    }
+
+    const VkVideoProfileInfoKHR* GetEncodeH265MainProfile() const {
+        static const VkVideoEncodeH265ProfileInfoKHR encode_h265_main = {VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR,
+                                                                         nullptr, STD_VIDEO_H265_PROFILE_IDC_MAIN};
+        static const VkVideoProfileInfoKHR encode_h265 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &encode_h265_main,
+            VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,       VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR};
+        return &encode_h265;
+    }
+
+    const VkVideoProfileInfoKHR* GetEncodeH265Main10Profile() const {
+        static const VkVideoEncodeH265ProfileInfoKHR encode_h265_main_10 = {VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR,
+                                                                            nullptr, STD_VIDEO_H265_PROFILE_IDC_MAIN_10};
+        static const VkVideoProfileInfoKHR encode_h265 = {
+            VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,     &encode_h265_main_10,
+            VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
+            VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR,      VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR};
+        return &encode_h265;
+    }
+
+    static void TearDownTestSuite() { inst_builder.reset(); }
+};
+
+TEST_F(TestsMechanismVideoProfiles, VideoCapabilities) {
+    TEST_DESCRIPTION("Test video capabilities of the profile defined video profiles");
+
+    struct VideoCapabilities {
+        VideoCapabilities(const VkVideoProfileInfoKHR* profile_info) {
+            switch (profile_info->videoCodecOperation) {
+                case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR:
+                    base.pNext = &decode;
+                    decode.pNext = &decode_h264;
+                    break;
+                case VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR:
+                    base.pNext = &decode;
+                    decode.pNext = &decode_h265;
+                    break;
+                case VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR:
+                    base.pNext = &encode;
+                    encode.pNext = &encode_h264;
+                    break;
+                case VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR:
+                    base.pNext = &encode;
+                    encode.pNext = &encode_h265;
+                    break;
+                default:
+                    assert(false);
+                    break;
+            }
+        }
+
+        VkVideoCapabilitiesKHR base{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR};
+        VkVideoDecodeCapabilitiesKHR decode{VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR};
+        VkVideoDecodeH264CapabilitiesKHR decode_h264{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR};
+        VkVideoDecodeH265CapabilitiesKHR decode_h265{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR};
+        VkVideoEncodeCapabilitiesKHR encode{VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR};
+        VkVideoEncodeH264CapabilitiesKHR encode_h264{VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR};
+        VkVideoEncodeH265CapabilitiesKHR encode_h265{VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR};
+    };
+
+    // H.264 Decode (4:2:0 8-bit) Baseline progressive
+    {
+        auto profile = GetDecodeH264BaselineProfile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 256);
+        EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+        EXPECT_EQ(caps.base.maxCodedExtent.width, 1920);
+        EXPECT_EQ(caps.base.maxCodedExtent.height, 1080);
+        EXPECT_EQ(caps.base.maxDpbSlots, 17);
+        EXPECT_EQ(caps.base.maxActiveReferencePictures, 16);
+        EXPECT_EQ(caps.decode_h264.maxLevelIdc, STD_VIDEO_H264_LEVEL_IDC_6_1);
+    }
+
+    // H.264 Decode (4:2:0 8-bit) Main interlaced
+    {
+        auto profile = GetDecodeH264MainProfile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 256);
+        EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+        EXPECT_EQ(caps.base.maxCodedExtent.width, 1280);
+        EXPECT_EQ(caps.base.maxCodedExtent.height, 1024);
+        EXPECT_EQ(caps.base.maxDpbSlots, 33);
+        EXPECT_EQ(caps.base.maxActiveReferencePictures, 32);
+        EXPECT_EQ(caps.decode_h264.maxLevelIdc, STD_VIDEO_H264_LEVEL_IDC_5_0);
+        EXPECT_EQ(caps.decode_h264.fieldOffsetGranularity.x, 48);
+        EXPECT_EQ(caps.decode_h264.fieldOffsetGranularity.y, 16);
+    }
+
+    // H.264 Decode (4:2:0 8-bit) Main
+    {
+        auto profile = GetDecodeH265MainProfile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 1024);
+        EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+        EXPECT_EQ(caps.base.maxCodedExtent.width, 3840);
+        EXPECT_EQ(caps.base.maxCodedExtent.height, 2160);
+        EXPECT_EQ(caps.base.maxDpbSlots, 17);
+        EXPECT_EQ(caps.base.maxActiveReferencePictures, 16);
+        EXPECT_EQ(caps.decode_h265.maxLevelIdc, STD_VIDEO_H265_LEVEL_IDC_5_0);
+    }
+
+    // H.264 Decode (4:2:0 10-bit) Main 10
+    {
+        auto profile = GetDecodeH265Main10Profile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 4096);
+        EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+        EXPECT_EQ(caps.base.maxCodedExtent.width, 2560);
+        EXPECT_EQ(caps.base.maxCodedExtent.height, 1440);
+        EXPECT_EQ(caps.base.maxDpbSlots, 17);
+        EXPECT_EQ(caps.base.maxActiveReferencePictures, 16);
+        EXPECT_EQ(caps.decode_h265.maxLevelIdc, STD_VIDEO_H265_LEVEL_IDC_4_1);
+    }
+
+    // H.264 Encode (4:2:0 8-bit) Baseline
+    {
+        auto profile = GetEncodeH264BaselineProfile();
+        VideoCapabilities caps(profile);
+
+        // Test with and without quantization map capabilities
+        VkVideoEncodeQuantizationMapCapabilitiesKHR caps_quant_map{VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR,
+                                                                   caps.base.pNext};
+        for (uint32_t i = 0; i < 2; ++i) {
+            if (i == 1) {
+                caps.base.pNext = &caps_quant_map;
+            }
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+            EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 4096);
+            EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+            EXPECT_EQ(caps.base.maxCodedExtent.width, 1920);
+            EXPECT_EQ(caps.base.maxCodedExtent.height, 1080);
+            EXPECT_EQ(caps.base.maxDpbSlots, 2);
+            EXPECT_EQ(caps.base.maxActiveReferencePictures, 1);
+            EXPECT_EQ(caps.encode.flags, VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_EMPHASIS_MAP_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_QUANTIZATION_DELTA_MAP_BIT_KHR);
+            EXPECT_EQ(caps.encode.maxRateControlLayers, 1);
+            EXPECT_EQ(caps.encode.supportedEncodeFeedbackFlags, VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+                                                                    VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR);
+            EXPECT_EQ(caps.encode_h264.flags, VK_VIDEO_ENCODE_H264_CAPABILITY_GENERATE_PREFIX_NALU_BIT_KHR);
+            EXPECT_EQ(caps.encode_h264.maxSliceCount, 4);
+            EXPECT_EQ(caps.encode_h264.maxPPictureL0ReferenceCount, 1);
+
+            if (i == 1) {
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.width, 256);
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.height, 256);
+            }
+        }
+    }
+
+    // H.264 Encode (4:2:0 8-bit) Main
+    {
+        auto profile = GetEncodeH264MainProfile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        // Test with and without quantization map capabilities
+        VkVideoEncodeQuantizationMapCapabilitiesKHR caps_quant_map{VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR,
+                                                                   caps.base.pNext};
+        for (uint32_t i = 0; i < 2; ++i) {
+            if (i == 1) {
+                caps.base.pNext = &caps_quant_map;
+            }
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+            EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 4096);
+            EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+            EXPECT_EQ(caps.base.maxCodedExtent.width, 960);
+            EXPECT_EQ(caps.base.maxCodedExtent.height, 1024);
+            EXPECT_EQ(caps.base.maxDpbSlots, 2);
+            EXPECT_EQ(caps.base.maxActiveReferencePictures, 1);
+            EXPECT_EQ(caps.encode.flags, VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_EMPHASIS_MAP_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_QUANTIZATION_DELTA_MAP_BIT_KHR);
+            EXPECT_EQ(caps.encode.maxRateControlLayers, 1);
+            EXPECT_EQ(caps.encode.supportedEncodeFeedbackFlags, VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+                                                                    VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR);
+            EXPECT_EQ(caps.encode_h264.flags, VK_VIDEO_ENCODE_H264_CAPABILITY_GENERATE_PREFIX_NALU_BIT_KHR);
+            EXPECT_EQ(caps.encode_h264.maxSliceCount, 1);
+            EXPECT_EQ(caps.encode_h264.maxPPictureL0ReferenceCount, 2);
+
+            if (i == 1) {
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.width, 256);
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.height, 256);
+            }
+        }
+    }
+
+    // H.265 Encode (4:2:0 8-bit) Main
+    {
+        auto profile = GetEncodeH265MainProfile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        // Test with and without quantization map capabilities
+        VkVideoEncodeQuantizationMapCapabilitiesKHR caps_quant_map{VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR,
+                                                                   caps.base.pNext};
+        for (uint32_t i = 0; i < 2; ++i) {
+            if (i == 1) {
+                caps.base.pNext = &caps_quant_map;
+            }
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+            EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 4096);
+            EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+            EXPECT_EQ(caps.base.maxCodedExtent.width, 960);
+            EXPECT_EQ(caps.base.maxCodedExtent.height, 1024);
+            EXPECT_EQ(caps.base.maxDpbSlots, 3);
+            EXPECT_EQ(caps.base.maxActiveReferencePictures, 2);
+            EXPECT_EQ(caps.encode.flags, VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_EMPHASIS_MAP_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_QUANTIZATION_DELTA_MAP_BIT_KHR);
+            EXPECT_EQ(caps.encode.maxRateControlLayers, 1);
+            EXPECT_EQ(caps.encode.supportedEncodeFeedbackFlags, VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+                                                                    VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR);
+            EXPECT_EQ(caps.encode_h265.maxSliceSegmentCount, 3);
+            EXPECT_EQ(caps.encode_h265.maxBPictureL0ReferenceCount, 1);
+            EXPECT_EQ(caps.encode_h265.maxL1ReferenceCount, 1);
+
+            if (i == 1) {
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.width, 192);
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.height, 128);
+            }
+        }
+    }
+
+    // H.265 Encode (4:2:0 10-bit) Main 10
+    {
+        auto profile = GetEncodeH265Main10Profile();
+        VideoCapabilities caps(profile);
+
+        EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+        // Test with and without quantization map capabilities
+        VkVideoEncodeQuantizationMapCapabilitiesKHR caps_quant_map{VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR,
+                                                                   caps.base.pNext};
+        for (uint32_t i = 0; i < 2; ++i) {
+            if (i == 1) {
+                caps.base.pNext = &caps_quant_map;
+            }
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoCapabilitiesKHR(gpu, profile, &caps.base), VK_SUCCESS);
+
+            EXPECT_EQ(caps.base.minBitstreamBufferOffsetAlignment, 4096);
+            EXPECT_EQ(caps.base.minBitstreamBufferSizeAlignment, 4096);
+            EXPECT_EQ(caps.base.maxCodedExtent.width, 1280);
+            EXPECT_EQ(caps.base.maxCodedExtent.height, 1024);
+            EXPECT_EQ(caps.base.maxDpbSlots, 2);
+            EXPECT_EQ(caps.base.maxActiveReferencePictures, 1);
+            EXPECT_EQ(caps.encode.flags, VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR |
+                                             VK_VIDEO_ENCODE_CAPABILITY_EMPHASIS_MAP_BIT_KHR);
+            EXPECT_EQ(caps.encode.maxRateControlLayers, 1);
+            EXPECT_EQ(caps.encode.supportedEncodeFeedbackFlags, VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR |
+                                                                    VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR);
+            EXPECT_EQ(caps.encode_h265.maxSliceSegmentCount, 1);
+
+            if (i == 1) {
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.width, 64);
+                EXPECT_EQ(caps_quant_map.maxQuantizationMapExtent.height, 64);
+            }
+        }
+    }
+}
+
+TEST_F(TestsMechanismVideoProfiles, VideoFormatProperties) {
+    TEST_DESCRIPTION("Test video format properties of the profile defined video profiles");
+
+    const uint32_t max_formats = 256;
+    std::vector<VkVideoFormatPropertiesKHR> fmt_props(max_formats);
+    std::vector<VkVideoFormatQuantizationMapPropertiesKHR> quant_map_props(max_formats);
+    std::vector<VkVideoFormatH265QuantizationMapPropertiesKHR> quant_map_props_h265(max_formats);
+    for (uint32_t i = 0; i < max_formats; ++i) {
+        fmt_props[i].sType = VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR;
+        fmt_props[i].pNext = &quant_map_props[i];
+        quant_map_props[i].sType = VK_STRUCTURE_TYPE_VIDEO_FORMAT_QUANTIZATION_MAP_PROPERTIES_KHR;
+        quant_map_props[i].pNext = &quant_map_props_h265[i];
+        quant_map_props_h265[i].sType = VK_STRUCTURE_TYPE_VIDEO_FORMAT_H265_QUANTIZATION_MAP_PROPERTIES_KHR;
+    }
+
+    struct VideoFormatInfo {
+        VideoFormatInfo(const VkVideoProfileInfoKHR* profile, VkImageUsageFlags usage) {
+            info.pNext = &profile_list;
+            info.imageUsage = usage;
+            profile_list.profileCount = 1;
+            profile_list.pProfiles = profile;
+        }
+
+        VkPhysicalDeviceVideoFormatInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR};
+        VkVideoProfileListInfoKHR profile_list{VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR};
+    };
+
+    // H.264 Decode (4:2:0 8-bit) Baseline progressive
+    {
+        auto profile = GetDecodeH264BaselineProfile();
+
+        // Decode Output
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_g8_b8r8 = false;
+            bool found_g8_b8_r8 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found_g8_b8r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found_g8_b8_r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_g8_b8r8);
+            EXPECT_TRUE(found_g8_b8_r8);
+        }
+
+        // Decode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.264 Decode (4:2:0 8-bit) Main interlaced
+    {
+        auto profile = GetDecodeH264MainProfile();
+
+        // Decode Output
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_g8_b8r8 = false;
+            bool found_g8_b8_r8 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found_g8_b8r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found_g8_b8_r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_g8_b8r8);
+            EXPECT_TRUE(found_g8_b8_r8);
+        }
+
+        // Decode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.264 Decode (4:2:0 8-bit) Main
+    {
+        auto profile = GetDecodeH265MainProfile();
+
+        // Decode Output
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_g8_b8r8 = false;
+            bool found_g8_b8_r8 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found_g8_b8r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found_g8_b8_r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_g8_b8r8);
+            EXPECT_TRUE(found_g8_b8_r8);
+        }
+
+        // Decode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.264 Decode (4:2:0 10-bit) Main 10
+    {
+        auto profile = GetDecodeH265Main10Profile();
+
+        // Decode Output
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16 &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Decode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.264 Encode (4:2:0 8-bit) Baseline
+    {
+        auto profile = GetEncodeH264BaselineProfile();
+
+        // Encode Input
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_g8_b8r8 = false;
+            bool found_g8_b8_r8 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found_g8_b8r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found_g8_b8_r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_g8_b8r8);
+            EXPECT_TRUE(found_g8_b8_r8);
+        }
+
+        // Encode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Quantization Delta Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R8_SINT && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 16 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 16) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR |
+                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Emphasis Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R8_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 64 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 64) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.264 Encode (4:2:0 8-bit) Main
+    {
+        auto profile = GetEncodeH264MainProfile();
+
+        // Encode Input
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_g8_b8r8 = false;
+            bool found_g8_b8_r8 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found_g8_b8r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found_g8_b8_r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_g8_b8r8);
+            EXPECT_TRUE(found_g8_b8_r8);
+        }
+
+        // Encode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Quantization Delta Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R8_SINT && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 16 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 16) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR |
+                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Emphasis Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R8_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 64 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 64) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.265 Encode (4:2:0 8-bit) Main
+    {
+        auto profile = GetEncodeH265MainProfile();
+
+        // Encode Input
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_g8_b8r8 = false;
+            bool found_g8_b8_r8 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found_g8_b8r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found_g8_b8_r8 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_g8_b8r8);
+            EXPECT_TRUE(found_g8_b8_r8);
+        }
+
+        // Encode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Quantization Delta Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 2);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found_16x16 = false;
+            bool found_32x32 = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R32_SINT && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 16 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 16) {
+                    found_16x16 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR |
+                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+                    EXPECT_EQ(quant_map_props_h265[i].compatibleCtbSizes, VK_VIDEO_ENCODE_H265_CTB_SIZE_16_BIT_KHR);
+                }
+
+                if (fmt_props[i].format == VK_FORMAT_R32_SINT && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 32 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 32) {
+                    found_32x32 = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags,
+                              VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+                    EXPECT_EQ(quant_map_props_h265[i].compatibleCtbSizes,
+                              VK_VIDEO_ENCODE_H265_CTB_SIZE_16_BIT_KHR | VK_VIDEO_ENCODE_H265_CTB_SIZE_32_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found_16x16);
+            EXPECT_TRUE(found_32x32);
+        }
+
+        // Emphasis Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R8_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 64 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 64) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+
+    // H.265 Encode (4:2:0 10-bit) Main 10
+    {
+        auto profile = GetEncodeH265Main10Profile();
+
+        // Encode Input
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16 &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags,
+                              VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                                VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                                VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Encode DPB
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_G16_B16R16_2PLANE_420_UNORM &&
+                    fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        // Emphasis Map
+        {
+            VideoFormatInfo info(profile, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+            uint32_t count = 0;
+
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, nullptr), VK_SUCCESS);
+            EXPECT_GE(count, 1);
+            const uint32_t count_received = count;
+
+            count = max_formats;
+            EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &info.info, &count, fmt_props.data()), VK_SUCCESS);
+            EXPECT_EQ(count, count_received);
+
+            bool found = false;
+
+            for (uint32_t i = 0; i < count; ++i) {
+                if (fmt_props[i].format == VK_FORMAT_R8_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+                    quant_map_props[i].quantizationMapTexelSize.width == 64 &&
+                    quant_map_props[i].quantizationMapTexelSize.height == 64) {
+                    found = true;
+                    EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+                    EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+                    EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+                    EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+    }
+}
+
+TEST_F(TestsMechanismVideoProfiles, VideoFormatPropertiesSharedTranscodeImage) {
+    TEST_DESCRIPTION("Test video format properties for transcoding case (one decode, multiple encode profiles)");
+
+    std::vector<VkVideoProfileInfoKHR> profiles{*GetDecodeH264BaselineProfile(), *GetEncodeH264BaselineProfile(),
+                                                *GetEncodeH264MainProfile(), *GetEncodeH265MainProfile()};
+
+    VkVideoProfileListInfoKHR profile_list{VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR};
+    profile_list.profileCount = static_cast<uint32_t>(profiles.size());
+    profile_list.pProfiles = profiles.data();
+
+    VkPhysicalDeviceVideoFormatInfoKHR fmt_info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR, &profile_list};
+    fmt_info.imageUsage = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR;
+
+    const uint32_t max_formats = 256;
+    std::vector<VkVideoFormatPropertiesKHR> fmt_props(max_formats, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR});
+
+    uint32_t count = 0;
+
+    EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &fmt_info, &count, nullptr), VK_SUCCESS);
+    EXPECT_GE(count, 2);
+    const uint32_t count_received = count;
+
+    count = max_formats;
+    EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &fmt_info, &count, fmt_props.data()), VK_SUCCESS);
+    EXPECT_EQ(count, count_received);
+
+    bool found_g8_b8r8 = false;
+    bool found_g8_b8_r8 = false;
+
+    for (uint32_t i = 0; i < count; ++i) {
+        if (fmt_props[i].format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR) {
+            found_g8_b8r8 = true;
+            EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].imageCreateFlags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+            EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+            EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                        VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                        VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+        }
+
+        if (fmt_props[i].format == VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_OPTIMAL) {
+            found_g8_b8_r8 = true;
+            EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].imageCreateFlags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+            EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+            EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                                        VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
+                                                        VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR);
+        }
+    }
+
+    EXPECT_TRUE(found_g8_b8r8);
+    EXPECT_TRUE(found_g8_b8_r8);
+}
+
+TEST_F(TestsMechanismVideoProfiles, VideoFormatPropertiesSharedQuantMap) {
+    TEST_DESCRIPTION("Test video format properties for shared quantization map format (multiple encode profiles)");
+
+    std::vector<VkVideoProfileInfoKHR> profiles{*GetEncodeH264BaselineProfile(), *GetEncodeH264MainProfile(),
+                                                *GetEncodeH265MainProfile(), *GetEncodeH265Main10Profile()};
+
+    VkVideoProfileListInfoKHR profile_list{VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR};
+    profile_list.profileCount = static_cast<uint32_t>(profiles.size());
+    profile_list.pProfiles = profiles.data();
+
+    VkPhysicalDeviceVideoFormatInfoKHR fmt_info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR, &profile_list};
+    fmt_info.imageUsage = VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR;
+
+    const uint32_t max_formats = 256;
+    std::vector<VkVideoFormatPropertiesKHR> fmt_props(max_formats);
+    std::vector<VkVideoFormatQuantizationMapPropertiesKHR> quant_map_props(max_formats);
+    for (uint32_t i = 0; i < max_formats; ++i) {
+        fmt_props[i].sType = VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR;
+        fmt_props[i].pNext = &quant_map_props[i];
+        quant_map_props[i].sType = VK_STRUCTURE_TYPE_VIDEO_FORMAT_QUANTIZATION_MAP_PROPERTIES_KHR;
+    }
+
+    uint32_t count = 0;
+
+    EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &fmt_info, &count, nullptr), VK_SUCCESS);
+    EXPECT_GE(count, 1);
+    const uint32_t count_received = count;
+
+    count = max_formats;
+    EXPECT_EQ(pfnGetPhysicalDeviceVideoFormatPropertiesKHR(gpu, &fmt_info, &count, fmt_props.data()), VK_SUCCESS);
+    EXPECT_EQ(count, count_received);
+
+    bool found = false;
+
+    for (uint32_t i = 0; i < count; ++i) {
+        if (fmt_props[i].format == VK_FORMAT_R8_UNORM && fmt_props[i].imageTiling == VK_IMAGE_TILING_LINEAR &&
+            quant_map_props[i].quantizationMapTexelSize.width == 64 && quant_map_props[i].quantizationMapTexelSize.height == 64) {
+            found = true;
+            EXPECT_EQ(fmt_props[i].componentMapping.r, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.g, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.b, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].componentMapping.a, VK_COMPONENT_SWIZZLE_IDENTITY);
+            EXPECT_EQ(fmt_props[i].imageCreateFlags, 0);
+            EXPECT_EQ(fmt_props[i].imageType, VK_IMAGE_TYPE_2D);
+            EXPECT_EQ(fmt_props[i].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR);
+        }
+    }
+
+    EXPECT_TRUE(found);
+}
+
+TEST_F(TestsMechanismVideoProfiles, VideoImageFormatProperties) {
+    TEST_DESCRIPTION("Test image format properties for video formats");
+
+    std::vector<VkVideoProfileInfoKHR> profiles{*GetDecodeH264BaselineProfile(), *GetEncodeH264BaselineProfile(),
+                                                *GetEncodeH264MainProfile(), *GetEncodeH265MainProfile()};
+
+    VkVideoProfileListInfoKHR profile_list{VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR};
+    profile_list.profileCount = static_cast<uint32_t>(profiles.size());
+    profile_list.pProfiles = profiles.data();
+
+    VkPhysicalDeviceImageFormatInfo2 fmt_info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR, &profile_list};
+    fmt_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+    fmt_info.type = VK_IMAGE_TYPE_2D;
+    fmt_info.tiling = VK_IMAGE_TILING_LINEAR;
+    fmt_info.usage = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR;
+    fmt_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+
+    VkImageFormatProperties2KHR fmt_props{VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2};
+
+    EXPECT_NE(vkGetPhysicalDeviceImageFormatProperties2(gpu, &fmt_info, &fmt_props),
+              VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR);
+
+    fmt_info.usage |= VK_IMAGE_USAGE_STORAGE_BIT;
+
+    EXPECT_EQ(vkGetPhysicalDeviceImageFormatProperties2(gpu, &fmt_info, &fmt_props),
+              VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR);
+}

--- a/layer/tests/tests_util.cpp
+++ b/layer/tests/tests_util.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2023-2023 Valve Corporation
  * Copyright (C) 2023-2023 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +86,10 @@ static SimulateCapabilityFlags GetSimulateCapability(const std::vector<std::stri
             result |= SIMULATE_FORMATS_BIT;
         } else if (values[i] == "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT") {
             result |= SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT;
+        } else if (values[i] == "SIMULATE_VIDEO_CAPABILITIES_BIT") {
+            result |= SIMULATE_VIDEO_CAPABILITIES_BIT;
+        } else if (values[i] == "SIMULATE_VIDEO_FORMATS_BIT") {
+            result |= SIMULATE_VIDEO_FORMATS_BIT;
         }
     }
 
@@ -92,8 +97,10 @@ static SimulateCapabilityFlags GetSimulateCapability(const std::vector<std::stri
 }
 
 static std::vector<std::string> GetSimulateCapabilityStrings(SimulateCapabilityFlags flags) {
-    static const char *table[] = {"SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT",
-                                  "SIMULATE_EXTENSIONS_BIT",  "SIMULATE_FORMATS_BIT",  "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT"};
+    static const char *table[] = {
+        "SIMULATE_API_VERSION_BIT",        "SIMULATE_FEATURES_BIT",     "SIMULATE_PROPERTIES_BIT",
+        "SIMULATE_EXTENSIONS_BIT",         "SIMULATE_FORMATS_BIT",      "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT",
+        "SIMULATE_VIDEO_CAPABILITIES_BIT", "SIMULATE_VIDEO_FORMATS_BIT"};
 
     std::vector<std::string> result;
 
@@ -115,6 +122,8 @@ TEST(TestsUtil, SimulateCapability) {
     EXPECT_STREQ("SIMULATE_EXTENSIONS_BIT", strings[3].c_str());
     EXPECT_STREQ("SIMULATE_FORMATS_BIT", strings[4].c_str());
     EXPECT_STREQ("SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT", strings[5].c_str());
+    EXPECT_STREQ("SIMULATE_VIDEO_CAPABILITIES_BIT", strings[6].c_str());
+    EXPECT_STREQ("SIMULATE_VIDEO_FORMATS_BIT", strings[7].c_str());
 
     SimulateCapabilityFlags flags = GetSimulateCapability(strings);
 
@@ -124,6 +133,8 @@ TEST(TestsUtil, SimulateCapability) {
     EXPECT_TRUE(flags & SIMULATE_EXTENSIONS_BIT);
     EXPECT_TRUE(flags & SIMULATE_FORMATS_BIT);
     EXPECT_TRUE(flags & SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT);
+    EXPECT_TRUE(flags & SIMULATE_VIDEO_CAPABILITIES_BIT);
+    EXPECT_TRUE(flags & SIMULATE_VIDEO_FORMATS_BIT);
 }
 
 TEST(TestsUtil, DefaultFeatureValues) {

--- a/library/test/profiles/VP_LUNARG_test_variants.json
+++ b/library/test/profiles/VP_LUNARG_test_variants.json
@@ -29,7 +29,17 @@
                         ]
                     }
                 }
-            }
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_TRANSFER_BIT"
+                        ],
+                        "queueCount": 2
+                    }
+                }
+            ]
         },
         "variant_a": {
             "extensions": {
@@ -58,7 +68,18 @@
                         ]
                     }
                 }
-            }
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_GRAPHICS_BIT",
+                            "VK_QUEUE_COMPUTE_BIT"
+                        ],
+                        "queueCount": 2
+                    }
+                }
+            ]
         },
         "variant_b": {
             "extensions": {
@@ -88,7 +109,25 @@
                         ]
                     }
                 }
-            }
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_COMPUTE_BIT"
+                        ],
+                        "queueCount": 2
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_PROTECTED_BIT"
+                        ],
+                        "queueCount": 1
+                    }
+                }
+            ]
         }
     },
     "profiles": {
@@ -111,11 +150,20 @@
                     "date": "2023-10-31",
                     "author": "Christophe Riccio",
                     "comment": "Initial revision"
+                },
+                {
+                    "revision": 2,
+                    "date": "2024-08-26",
+                    "author": "Daniel Rakos",
+                    "comment": "Update with queue family properties"
                 }
             ],
             "capabilities": [
                 "block",
-                [ "variant_a", "variant_b" ]
+                [
+                    "variant_a",
+                    "variant_b"
+                ]
             ]
         }
     }

--- a/library/test/profiles/VP_RASTERGRID_test_queue_families.json
+++ b/library/test/profiles/VP_RASTERGRID_test_queue_families.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.2-266.json#",
+    "capabilities": {
+        "block": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_decode_queue": 1,
+                "VK_KHR_video_decode_h264": 1,
+                "VK_KHR_video_decode_h265": 1,
+                "VK_KHR_video_encode_queue": 1
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_GRAPHICS_BIT",
+                            "VK_QUEUE_COMPUTE_BIT",
+                            "VK_QUEUE_TRANSFER_BIT"
+                        ],
+                        "queueCount": 1
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_VIDEO_DECODE_BIT_KHR"
+                        ],
+                        "queueCount": 1
+                    },
+                    "VkQueueFamilyVideoPropertiesKHR": {
+                        "videoCodecOperations": [
+                            "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR"
+                        ]
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_VIDEO_DECODE_BIT_KHR"
+                        ],
+                        "queueCount": 1
+                    },
+                    "VkQueueFamilyVideoPropertiesKHR": {
+                        "videoCodecOperations": [
+                            "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR"
+                        ]
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                        ],
+                        "queueCount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "profiles": {
+        "VP_RASTERGRID_test_queue_families": {
+            "version": 1,
+            "api-version": "1.3.225",
+            "label": "Test Profile Variants",
+            "description": "Test.",
+            "contributors": {
+                "Daniel Rakos": {
+                    "company": "RasterGrid",
+                    "email": "daniel.rakos@rastergrid.com",
+                    "github": "aqnuep",
+                    "contact": true
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2024-08-26",
+                    "author": "Daniel Rakos",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "block"
+            ]
+        }
+    }
+}

--- a/library/test/profiles/VP_RASTERGRID_test_video_profiles.json
+++ b/library/test/profiles/VP_RASTERGRID_test_video_profiles.json
@@ -1,0 +1,257 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.2-266.json#",
+    "capabilities": {
+        "block": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_decode_queue": 1
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_VIDEO_DECODE_BIT_KHR"
+                        ],
+                        "queueCount": 1
+                    }
+                }
+            ]
+        },
+        "variant_h264": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_decode_queue": 1,
+                "VK_KHR_video_decode_h264": 1
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyVideoPropertiesKHR": {
+                        "videoCodecOperations": [
+                            "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR"
+                        ]
+                    }
+                }
+            ],
+            "videoProfiles": [
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH264ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H264_PROFILE_IDC_MAIN",
+                            "pictureLayout": "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 1920,
+                                "height": 1080
+                            },
+                            "maxDpbSlots": 17,
+                            "maxActiveReferencePictures": 16
+                        },
+                        "VkVideoDecodeH264CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H264_LEVEL_IDC_5_2"
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "imageCreateFlags": [
+                                    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT",
+                                    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"
+                                ],
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_SAMPLED_BIT",
+                                    "VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
+                                    "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "variant_h265": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_decode_queue": 1,
+                "VK_KHR_video_decode_h265": 1
+            },
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyVideoPropertiesKHR": {
+                        "videoCodecOperations": [
+                            "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR"
+                        ]
+                    }
+                }
+            ],
+            "videoProfiles": [
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 3840,
+                                "height": 2160
+                            },
+                            "maxDpbSlots": 8,
+                            "maxActiveReferencePictures": 4
+                        },
+                        "VkVideoDecodeH265CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H265_LEVEL_IDC_6_0"
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "imageCreateFlags": [
+                                    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT",
+                                    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"
+                                ],
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
+                                    "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR",
+                                    "VK_IMAGE_USAGE_TRANSFER_SRC_BIT"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN_10"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 720,
+                                "height": 480
+                            },
+                            "maxDpbSlots": 2,
+                            "maxActiveReferencePictures": 1
+                        },
+                        "VkVideoDecodeH265CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H265_LEVEL_IDC_5_0"
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16",
+                                "imageCreateFlags": [
+                                    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT",
+                                    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"
+                                ],
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR",
+                                    "VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
+                                    "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "profiles": {
+        "VP_RASTERGRID_test_video_profiles": {
+            "version": 1,
+            "api-version": "1.3.225",
+            "label": "Test Video Profiles with Profile Variants",
+            "description": "Test.",
+            "contributors": {
+                "Daniel Rakos": {
+                    "company": "RasterGrid",
+                    "email": "daniel.rakos@rastergrid.com",
+                    "github": "aqnuep",
+                    "contact": true
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2024-08-28",
+                    "author": "Daniel Rakos",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "block",
+                [
+                    "variant_h264",
+                    "variant_h265"
+                ]
+            ]
+        }
+    }
+}

--- a/library/test/profiles/VP_RASTERGRID_test_wildcard_video_profiles.json
+++ b/library/test/profiles/VP_RASTERGRID_test_wildcard_video_profiles.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "capabilities": {
+        "general": {
+            "extensions": {
+                "VK_KHR_video_queue": 1
+            },
+            "videoProfiles": [
+                {
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 1920,
+                                "height": 1080
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "decode_420_8bit": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_decode_queue": 1
+            },
+            "videoProfiles": [
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoDecodeCapabilitiesKHR": {}
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "imageCreateFlags": [
+                                    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT",
+                                    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"
+                                ],
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "decode_h264": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_decode_queue": 1,
+                "VK_KHR_video_decode_h264": 1
+            },
+            "videoProfiles": [
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR"
+                        },
+                        "VkVideoDecodeH264ProfileInfoKHR": {
+                            "pictureLayout": "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxDpbSlots": 16,
+                            "maxActiveReferencePictures": 15
+                        },
+                        "VkVideoDecodeH264CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H264_LEVEL_IDC_6_0"
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_SAMPLED_BIT"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "profiles": {
+        "VP_RASTERGRID_test_wildcard_video_profiles": {
+            "version": 1,
+            "api-version": "1.1.276",
+            "label": "Sample video profile with video profile 'wildcards'",
+            "description": "Demonstration of 'wildcard' video profile requirements.",
+            "capabilities": [
+                "general",
+                "decode_420_8bit",
+                "decode_h264"
+            ]
+        }
+    }
+}

--- a/library/test/test_mocked_api_create_device.cpp
+++ b/library/test/test_mocked_api_create_device.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021-2024 Valve Corporation
  * Copyright (c) 2021-2024 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +37,10 @@ TEST(mocked_api_create_device, default_extensions) {
     inCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
     std::vector<const char *> outExtensions(
-        sizeof(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions) /
-        sizeof(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[0]));
+        sizeof(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions) /
+        sizeof(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[0]));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
 
     VkDeviceCreateInfo outCreateInfo = inCreateInfo;
@@ -88,9 +89,10 @@ TEST(mocked_api_create_device, merge_extensions) {
     inCreateInfo.enabledExtensionCount = static_cast<uint32_t>(inExtensions.size());
     inCreateInfo.ppEnabledExtensionNames = inExtensions.data();
 
-    std::vector<const char *> outExtensions(std::size(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions));
+    std::vector<const char *> outExtensions(
+        std::size(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
     outExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
@@ -133,9 +135,10 @@ TEST(mocked_api_create_device, default_features) {
     inCreateInfo.queueCreateInfoCount = 1;
     inCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
-    std::vector<const char *> outExtensions(std::size(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions));
+    std::vector<const char *> outExtensions(
+        std::size(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
 
     VkDeviceCreateInfo outCreateInfo = inCreateInfo;
@@ -186,9 +189,9 @@ TEST(mocked_api_create_device, legacy_enabled_features) {
     inCreateInfo.pEnabledFeatures = &inFeatures.features;
 
     std::vector<const char *> outExtensions(
-        std::size(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions));
+        std::size(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
 
     VkDeviceCreateInfo outCreateInfo = inCreateInfo;
@@ -233,9 +236,10 @@ TEST(mocked_api_create_device, disable_robust_buffer_access) {
     inCreateInfo.queueCreateInfoCount = 1;
     inCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
-    std::vector<const char *> outExtensions(std::size(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions));
+    std::vector<const char *> outExtensions(
+        std::size(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
 
     VkDeviceCreateInfo outCreateInfo = inCreateInfo;
@@ -281,9 +285,9 @@ TEST(mocked_api_create_device, disable_robust_image_access) {
     inCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
     std::vector<const char *> outExtensions(
-        std::size(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions));
+        std::size(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
 
     VkDeviceCreateInfo outCreateInfo = inCreateInfo;
@@ -327,9 +331,10 @@ TEST(mocked_api_create_device, disable_robust_access) {
     inCreateInfo.queueCreateInfoCount = 1;
     inCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 
-    std::vector<const char *> outExtensions(std::size(detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions));
+    std::vector<const char *> outExtensions(
+        std::size(detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_KHR_ROADMAP_2022::blocks::vulkan13requirements_roadmap2022::deviceExtensions[i].extensionName;
     }
 
     VkDeviceCreateInfo outCreateInfo = inCreateInfo;

--- a/library/test/test_mocked_api_create_instance.cpp
+++ b/library/test/test_mocked_api_create_instance.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021-2024 Valve Corporation
  * Copyright (c) 2021-2024 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,10 +160,10 @@ TEST(mocked_api_create_instance, default_extensions) {
     VkInstanceCreateInfo inCreateInfo{ VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
     inCreateInfo.pApplicationInfo = &inAppInfo;
 
-    std::vector<const char*> outExtensions(sizeof(detail::VP_ANDROID_BASELINE_2021::baseline::instanceExtensions) /
-                                           sizeof(detail::VP_ANDROID_BASELINE_2021::baseline::instanceExtensions[0]));
+    std::vector<const char*> outExtensions(sizeof(detail::VP_ANDROID_BASELINE_2021::blocks::baseline::instanceExtensions) /
+                                           sizeof(detail::VP_ANDROID_BASELINE_2021::blocks::baseline::instanceExtensions[0]));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_ANDROID_BASELINE_2021::baseline::instanceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_ANDROID_BASELINE_2021::blocks::baseline::instanceExtensions[i].extensionName;
     }
 
     VkInstanceCreateInfo outCreateInfo = inCreateInfo;
@@ -199,10 +200,10 @@ TEST(mocked_api_create_instance, merge_extensions) {
     inCreateInfo.enabledExtensionCount = static_cast<uint32_t>(inExtensions.size());
     inCreateInfo.ppEnabledExtensionNames = inExtensions.data();
 
-    std::vector<const char*> outExtensions(sizeof(detail::VP_ANDROID_BASELINE_2021::baseline::instanceExtensions) /
-                                           sizeof(detail::VP_ANDROID_BASELINE_2021::baseline::instanceExtensions[0]));
+    std::vector<const char*> outExtensions(sizeof(detail::VP_ANDROID_BASELINE_2021::blocks::baseline::instanceExtensions) /
+                                           sizeof(detail::VP_ANDROID_BASELINE_2021::blocks::baseline::instanceExtensions[0]));
     for (size_t i = 0; i < outExtensions.size(); ++i) {
-        outExtensions[i] = detail::VP_ANDROID_BASELINE_2021::baseline::instanceExtensions[i].extensionName;
+        outExtensions[i] = detail::VP_ANDROID_BASELINE_2021::blocks::baseline::instanceExtensions[i].extensionName;
     }
     outExtensions.push_back(VK_KHR_DISPLAY_EXTENSION_NAME);
 

--- a/library/test/test_mocked_api_generated_library.cpp
+++ b/library/test/test_mocked_api_generated_library.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023-2023 Valve Corporation
  * Copyright (c) 2023-2023 LunarG, Inc.
+ * Copyright (c) 2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,16 +47,127 @@ void initProfile(MockVulkanAPI& mock, const VpProfileProperties& profile, uint32
         mock.SetProperties({VK_STRUCT(props)});
     }
 
+    if (profileAreas & PROFILE_AREA_QUEUE_FAMILIES_BIT) {
+        uint32_t queue_family_count = 0;
+        vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, nullptr);
+        std::vector<VkQueueFamilyProperties2KHR> props(queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+        std::vector<VkQueueFamilyVideoPropertiesKHR> video_props(queue_family_count,
+                                                                 {VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR, nullptr});
+        for (uint32_t i = 0; i < queue_family_count; ++i) {
+            props[i].pNext = &video_props[i];
+        }
+        vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, props.data());
+        for (uint32_t i = 0; i < queue_family_count; ++i) {
+            mock.AddQueueFamily({VK_STRUCT(props[i]), VK_STRUCT(video_props[i])});
+        }
+    }
+
     if (profileAreas & PROFILE_AREA_FORMATS_BIT) {
         uint32_t formatCount = 0;
         vpGetProfileFormats(&profile, nullptr, &formatCount, nullptr);
-        std::vector<VkFormat> formats(formatCount);
-        vpGetProfileFormats(&profile, nullptr, &formatCount, &formats[0]);
+        if (formatCount > 0) {
+            std::vector<VkFormat> formats(formatCount);
+            vpGetProfileFormats(&profile, nullptr, &formatCount, &formats[0]);
 
-        for (std::size_t i = 0, n = formats.size(); i < n; ++i) {
-            VkFormatProperties2KHR formatProps{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR};
-            vpGetProfileFormatProperties(&profile, nullptr, formats[i], &formatProps);
-            mock.AddFormat(formats[i], {VK_STRUCT(formatProps)});
+            for (std::size_t i = 0, n = formats.size(); i < n; ++i) {
+                VkFormatProperties2KHR formatProps{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR};
+                vpGetProfileFormatProperties(&profile, nullptr, formats[i], &formatProps);
+                mock.AddFormat(formats[i], {VK_STRUCT(formatProps)});
+            }
+        }
+    }
+
+    auto get_video_profile = [&](uint32_t video_profile_index) {
+        VkVideoDecodeH264ProfileInfoKHR decode_h264{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR};
+        VkVideoDecodeH265ProfileInfoKHR decode_h265{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR};
+        VkVideoProfileInfoKHR profile_info{VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR};
+
+        uint32_t struct_type_count = 0;
+        vpGetProfileVideoProfileInfoStructureTypes(&profile, nullptr, video_profile_index, &struct_type_count, nullptr);
+        std::vector<VkStructureType> struct_types(struct_type_count);
+        vpGetProfileVideoProfileInfoStructureTypes(&profile, nullptr, video_profile_index, &struct_type_count, struct_types.data());
+
+        std::vector<VulkanStructData> struct_data{};
+        for (auto struct_type : struct_types) {
+            switch (struct_type) {
+                case VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR:
+                    break;
+                case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR:
+                    profile_info.pNext = &decode_h264;
+                    break;
+                case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR:
+                    profile_info.pNext = &decode_h265;
+                    break;
+                default:
+                    assert(false);
+                    break;
+            }
+        }
+
+        vpGetProfileVideoProfileInfo(&profile, nullptr, video_profile_index, &profile_info);
+        return VulkanVideoProfile(&profile_info);
+    };
+
+    if (profileAreas & PROFILE_AREA_VIDEO_CAPABILITIES_BIT) {
+        mock.InitVideoEntryPoints();
+
+        uint32_t video_profile_count = 0;
+        vpGetProfileVideoProfiles(&profile, nullptr, &video_profile_count, nullptr);
+        for (uint32_t video_profile_index = 0; video_profile_index < video_profile_count; ++video_profile_index) {
+            auto video_profile = get_video_profile(video_profile_index);
+
+            VkVideoDecodeH264CapabilitiesKHR h264_decode{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR, nullptr};
+            VkVideoDecodeH265CapabilitiesKHR h265_decode{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR, &h264_decode};
+            VkVideoCapabilitiesKHR caps{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, &h265_decode};
+            vpGetProfileVideoCapabilities(&profile, nullptr, video_profile_index, &caps);
+
+            uint32_t struct_type_count = 0;
+            vpGetProfileVideoCapabilityStructureTypes(&profile, nullptr, video_profile_index, &struct_type_count, nullptr);
+            std::vector<VkStructureType> struct_types(struct_type_count);
+            vpGetProfileVideoCapabilityStructureTypes(&profile, nullptr, video_profile_index, &struct_type_count,
+                                                      struct_types.data());
+
+            std::vector<VulkanStructData> struct_data{};
+            for (auto struct_type : struct_types) {
+                switch (struct_type) {
+                    case VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR:
+                        struct_data.emplace_back(VK_STRUCT(caps));
+                        break;
+                    case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR:
+                        struct_data.emplace_back(VK_STRUCT(h264_decode));
+                        break;
+                    case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR:
+                        struct_data.emplace_back(VK_STRUCT(h265_decode));
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            mock.AddVideoCapabilities(video_profile, std::move(struct_data));
+        }
+    }
+
+    if (profileAreas & PROFILE_AREA_VIDEO_FORMATS_BIT) {
+        mock.InitVideoEntryPoints();
+
+        uint32_t video_profile_count = 0;
+        vpGetProfileVideoProfiles(&profile, nullptr, &video_profile_count, nullptr);
+        for (uint32_t video_profile_index = 0; video_profile_index < video_profile_count; ++video_profile_index) {
+            auto video_profile = get_video_profile(video_profile_index);
+
+            uint32_t format_count = 0;
+            vpGetProfileVideoFormatProperties(&profile, nullptr, video_profile_index, &format_count, nullptr);
+
+            if (format_count > 0) {
+                std::vector<VkVideoFormatPropertiesKHR> props(format_count,
+                                                              {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+                vpGetProfileVideoFormatProperties(&profile, nullptr, video_profile_index, &format_count, props.data());
+
+                for (uint32_t i = 0; i < format_count; ++i) {
+                    mock.AddVideoFormat(video_profile, {VK_STRUCT(props[i])});
+                }
+            }
         }
     }
 }
@@ -326,6 +438,127 @@ TEST(mocked_api_generated_library, check_support_profile_c) {
     EXPECT_EQ(supported, VK_TRUE);
 }
 
+TEST(mocked_api_generated_library, check_support_profile_queue_families) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_QUEUE_FAMILIES_NAME, VP_RASTERGRID_TEST_QUEUE_FAMILIES_SPEC_VERSION};
+
+    VkBool32 multiple_variants = VK_TRUE;
+    VkResult result = vpHasMultipleVariantsProfile(&profile, &multiple_variants);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(multiple_variants, VK_FALSE);
+
+    const uint32_t api_version = vpGetProfileAPIVersion(&profile);
+    EXPECT_EQ(VK_API_VERSION_MAJOR(api_version), 1);
+    EXPECT_EQ(VK_API_VERSION_MINOR(api_version), 3);
+    EXPECT_EQ(VK_API_VERSION_PATCH(api_version), 225);
+
+    uint32_t extensions_count = 0;
+    vpGetProfileDeviceExtensionProperties(&profile, nullptr, &extensions_count, nullptr);
+    std::vector<VkExtensionProperties> extensions(extensions_count);
+    vpGetProfileDeviceExtensionProperties(&profile, nullptr, &extensions_count, &extensions[0]);
+
+    EXPECT_EQ(extensions_count, 5);
+
+    EXPECT_STREQ(extensions[0].extensionName, "VK_KHR_video_decode_h264");
+    EXPECT_STREQ(extensions[1].extensionName, "VK_KHR_video_decode_h265");
+    EXPECT_STREQ(extensions[2].extensionName, "VK_KHR_video_decode_queue");
+    EXPECT_STREQ(extensions[3].extensionName, "VK_KHR_video_encode_queue");
+    EXPECT_STREQ(extensions[4].extensionName, "VK_KHR_video_queue");
+
+    uint32_t queue_family_count = 0;
+    vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, nullptr);
+
+    EXPECT_EQ(queue_family_count, 4);
+
+    std::vector<VkQueueFamilyProperties2> queue_family_props(queue_family_count,
+                                                             {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+    std::vector<VkQueueFamilyVideoPropertiesKHR> queue_family_video_props(
+        queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR, nullptr});
+    for (uint32_t i = 0; i < queue_family_count; ++i) {
+        queue_family_props[i].pNext = &queue_family_video_props[i];
+    }
+    vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, queue_family_props.data());
+
+    EXPECT_EQ(queue_family_count, 4);
+
+    EXPECT_EQ(queue_family_props[0].queueFamilyProperties.queueFlags,
+              VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT);
+    EXPECT_EQ(queue_family_props[0].queueFamilyProperties.queueCount, 1);
+    EXPECT_EQ(queue_family_video_props[0].videoCodecOperations, 0);
+
+    EXPECT_EQ(queue_family_props[1].queueFamilyProperties.queueFlags, VK_QUEUE_VIDEO_DECODE_BIT_KHR);
+    EXPECT_EQ(queue_family_props[1].queueFamilyProperties.queueCount, 1);
+    EXPECT_EQ(queue_family_video_props[1].videoCodecOperations, VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR);
+
+    EXPECT_EQ(queue_family_props[2].queueFamilyProperties.queueFlags, VK_QUEUE_VIDEO_DECODE_BIT_KHR);
+    EXPECT_EQ(queue_family_props[2].queueFamilyProperties.queueCount, 1);
+    EXPECT_EQ(queue_family_video_props[2].videoCodecOperations, VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR);
+
+    EXPECT_EQ(queue_family_props[3].queueFamilyProperties.queueFlags, VK_QUEUE_VIDEO_ENCODE_BIT_KHR);
+    EXPECT_EQ(queue_family_props[3].queueFamilyProperties.queueCount, 1);
+    EXPECT_EQ(queue_family_video_props[3].videoCodecOperations, 0);
+
+    mock.SetDeviceExtensions(mock.vkPhysicalDevice, extensions);
+    mock.SetInstanceAPIVersion(VK_API_VERSION_1_3);
+    mock.SetDeviceAPIVersion(VK_API_VERSION_1_3);
+    for (uint32_t i = 0; i < queue_family_count; ++i) {
+        mock.AddQueueFamily({VK_STRUCT(queue_family_props[i]), VK_STRUCT(queue_family_video_props[i])});
+    }
+
+    VkBool32 supported = VK_FALSE;
+    result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_TRUE);
+
+    // Test also that it's fine to expose multiple required queue flags on the same queue family
+    queue_family_props[0].queueFamilyProperties.queueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
+    queue_family_props[0].queueFamilyProperties.queueCount = 1;
+    queue_family_video_props[0].videoCodecOperations = 0;
+
+    queue_family_props[1].queueFamilyProperties.queueFlags = VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_VIDEO_ENCODE_BIT_KHR;
+    queue_family_props[1].queueFamilyProperties.queueCount = 1;
+    queue_family_video_props[1].videoCodecOperations =
+        VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR | VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR;
+
+    mock.ClearProfileAreas(PROFILE_AREA_QUEUE_FAMILIES_BIT);
+    for (uint32_t i = 0; i < 2; ++i) {
+        mock.AddQueueFamily({VK_STRUCT(queue_family_props[i]), VK_STRUCT(queue_family_video_props[i])});
+    }
+
+    supported = VK_FALSE;
+    result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_TRUE);
+
+    // But if queue flags required by a single queue family are split across multiple queue families, then it is not accepted
+    queue_family_props[0].queueFamilyProperties.queueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT;
+    queue_family_props[0].queueFamilyProperties.queueCount = 1;
+    queue_family_video_props[0].videoCodecOperations = 0;
+
+    queue_family_props[1].queueFamilyProperties.queueFlags = VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
+    queue_family_props[1].queueFamilyProperties.queueCount = 1;
+    queue_family_video_props[1].videoCodecOperations = 0;
+
+    queue_family_props[2].queueFamilyProperties.queueFlags = VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_VIDEO_ENCODE_BIT_KHR;
+    queue_family_props[2].queueFamilyProperties.queueCount = 1;
+    queue_family_video_props[2].videoCodecOperations =
+        VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR | VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR;
+
+    mock.ClearProfileAreas(PROFILE_AREA_QUEUE_FAMILIES_BIT);
+    for (uint32_t i = 0; i < 3; ++i) {
+        mock.AddQueueFamily({VK_STRUCT(queue_family_props[i]), VK_STRUCT(queue_family_video_props[i])});
+    }
+
+    supported = VK_TRUE;
+    result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_FALSE);
+}
+
 TEST(mocked_api_generated_library, check_support_variants_reflection) {
     MockVulkanAPI mock;
 
@@ -462,6 +695,110 @@ TEST(mocked_api_generated_library, check_support_variants_property_reflection) {
 
     result = vpGetProfileProperties(&profile, "variant_unknown", &props);
     EXPECT_EQ(result, VK_INCOMPLETE);
+}
+
+TEST(mocked_api_generated_library, check_support_variants_queue_family_reflection) {
+    const VpProfileProperties profile{VP_LUNARG_TEST_VARIANTS_NAME, VP_LUNARG_TEST_VARIANTS_SPEC_VERSION};
+
+    VkResult result = VK_SUCCESS;
+    uint32_t queue_family_count = 0;
+    std::vector<VkQueueFamilyProperties2KHR> props{};
+
+    const VpProfileProperties profileUnknown{"pouet", 1};
+    result = vpGetProfileQueueFamilyProperties(&profileUnknown, nullptr, &queue_family_count, nullptr);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    result = vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 4);
+
+    props.resize(queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+    result = vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 4);
+
+    EXPECT_EQ(props[0].queueFamilyProperties.queueFlags, VK_QUEUE_TRANSFER_BIT);
+    EXPECT_EQ(props[0].queueFamilyProperties.queueCount, 2);
+    EXPECT_EQ(props[1].queueFamilyProperties.queueFlags, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
+    EXPECT_EQ(props[1].queueFamilyProperties.queueCount, 2);
+    EXPECT_EQ(props[2].queueFamilyProperties.queueFlags, VK_QUEUE_COMPUTE_BIT);
+    EXPECT_EQ(props[2].queueFamilyProperties.queueCount, 2);
+    EXPECT_EQ(props[3].queueFamilyProperties.queueFlags, VK_QUEUE_PROTECTED_BIT);
+    EXPECT_EQ(props[3].queueFamilyProperties.queueCount, 1);
+
+    queue_family_count = 2;
+    props.clear();
+    props.resize(queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+    result = vpGetProfileQueueFamilyProperties(&profile, nullptr, &queue_family_count, props.data());
+    EXPECT_EQ(result, VK_INCOMPLETE);
+    EXPECT_EQ(queue_family_count, 2);
+
+    EXPECT_EQ(props[0].queueFamilyProperties.queueFlags, VK_QUEUE_TRANSFER_BIT);
+    EXPECT_EQ(props[0].queueFamilyProperties.queueCount, 2);
+    EXPECT_EQ(props[1].queueFamilyProperties.queueFlags, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
+    EXPECT_EQ(props[1].queueFamilyProperties.queueCount, 2);
+
+    result = vpGetProfileQueueFamilyProperties(&profile, "block", &queue_family_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 1);
+
+    props.clear();
+    props.resize(queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+    result = vpGetProfileQueueFamilyProperties(&profile, "block", &queue_family_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 1);
+
+    EXPECT_EQ(props[0].queueFamilyProperties.queueFlags, VK_QUEUE_TRANSFER_BIT);
+    EXPECT_EQ(props[0].queueFamilyProperties.queueCount, 2);
+
+    result = vpGetProfileQueueFamilyProperties(&profile, "variant_a", &queue_family_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 1);
+
+    props.clear();
+    props.resize(queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+    result = vpGetProfileQueueFamilyProperties(&profile, "variant_a", &queue_family_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 1);
+
+    EXPECT_EQ(props[0].queueFamilyProperties.queueFlags, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
+    EXPECT_EQ(props[0].queueFamilyProperties.queueCount, 2);
+
+    result = vpGetProfileQueueFamilyProperties(&profile, "variant_b", &queue_family_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 2);
+
+    props.clear();
+    props.resize(queue_family_count, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr});
+    result = vpGetProfileQueueFamilyProperties(&profile, "variant_b", &queue_family_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(queue_family_count, 2);
+
+    EXPECT_EQ(props[0].queueFamilyProperties.queueFlags, VK_QUEUE_COMPUTE_BIT);
+    EXPECT_EQ(props[0].queueFamilyProperties.queueCount, 2);
+    EXPECT_EQ(props[1].queueFamilyProperties.queueFlags, VK_QUEUE_PROTECTED_BIT);
+    EXPECT_EQ(props[1].queueFamilyProperties.queueCount, 1);
+
+    result = vpGetProfileQueueFamilyProperties(&profile, "variant_unknown", &queue_family_count, nullptr);
+    EXPECT_EQ(result, VK_INCOMPLETE);
+
+    const VpProfileProperties profile2{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    uint32_t structure_type_count = 0;
+    result = vpGetProfileQueueFamilyStructureTypes(&profile2, "pouet", &structure_type_count, nullptr);
+    EXPECT_EQ(result, VK_INCOMPLETE);
+    EXPECT_EQ(structure_type_count, 0);
+
+    result = vpGetProfileQueueFamilyStructureTypes(&profile2, nullptr, &structure_type_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(structure_type_count, 2);
+
+    std::vector<VkStructureType> structure_types(structure_type_count);
+    result = vpGetProfileQueueFamilyStructureTypes(&profile2, nullptr, &structure_type_count, structure_types.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(structure_type_count, 2);
+    EXPECT_EQ(structure_types[0], VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR);
+    EXPECT_EQ(structure_types[1], VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2);
 }
 
 TEST(mocked_api_generated_library, check_support_variants_format_reflection) {
@@ -808,7 +1145,127 @@ TEST(mocked_api_generated_library, check_support_variants_properties_fail) {
     EXPECT_EQ(block_property_count, 2);
 }
 
-TEST(mocked_api_generated_library, check_support_variants_format_success_1variants) {
+TEST(mocked_api_generated_library, check_support_variants_queue_family_success_2variants) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_LUNARG_TEST_VARIANTS_NAME, VP_LUNARG_TEST_VARIANTS_SPEC_VERSION};
+
+    initProfile(mock, profile);
+    fixProperties(mock);
+
+    mock.ClearProfileAreas(PROFILE_AREA_QUEUE_FAMILIES_BIT);
+
+    VkQueueFamilyProperties2KHR props{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2};
+
+    props.queueFamilyProperties.queueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
+    props.queueFamilyProperties.queueCount = 2;
+    mock.AddQueueFamily({VK_STRUCT(props)});
+
+    props.queueFamilyProperties.queueFlags = VK_QUEUE_TRANSFER_BIT | VK_QUEUE_PROTECTED_BIT;
+    props.queueFamilyProperties.queueCount = 1;
+    mock.AddQueueFamily({VK_STRUCT(props)});
+
+    VkBool32 supported = VK_FALSE;
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_TRUE);
+
+    std::vector<VpBlockProperties> block_properties(10);
+    uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+    supported = VK_FALSE;
+    result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                       &block_property_count, &block_properties[0]);
+
+    EXPECT_EQ(supported, VK_TRUE);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(block_property_count, 2);
+    EXPECT_STREQ(block_properties[0].blockName, "block");
+    EXPECT_STREQ(block_properties[1].blockName, "variant_a");
+}
+
+TEST(mocked_api_generated_library, check_support_variants_queue_family_success_1variant) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_LUNARG_TEST_VARIANTS_NAME, VP_LUNARG_TEST_VARIANTS_SPEC_VERSION};
+
+    initProfile(mock, profile);
+    fixProperties(mock);
+
+    mock.ClearProfileAreas(PROFILE_AREA_QUEUE_FAMILIES_BIT);
+
+    VkQueueFamilyProperties2KHR props{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2};
+
+    props.queueFamilyProperties.queueFlags = VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
+    props.queueFamilyProperties.queueCount = 2;
+    mock.AddQueueFamily({VK_STRUCT(props)});
+
+    props.queueFamilyProperties.queueFlags = VK_QUEUE_TRANSFER_BIT | VK_QUEUE_PROTECTED_BIT;
+    props.queueFamilyProperties.queueCount = 1;
+    mock.AddQueueFamily({VK_STRUCT(props)});
+
+    VkBool32 supported = VK_FALSE;
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_TRUE);
+
+    std::vector<VpBlockProperties> block_properties(10);
+    uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+    supported = VK_FALSE;
+    result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                       &block_property_count, &block_properties[0]);
+
+    EXPECT_EQ(supported, VK_TRUE);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(block_property_count, 2);
+    EXPECT_STREQ(block_properties[0].blockName, "block");
+    EXPECT_STREQ(block_properties[1].blockName, "variant_b");
+}
+
+TEST(mocked_api_generated_library, check_support_variants_queue_family_fail) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_LUNARG_TEST_VARIANTS_NAME, VP_LUNARG_TEST_VARIANTS_SPEC_VERSION};
+
+    initProfile(mock, profile);
+    fixProperties(mock);
+
+    mock.ClearProfileAreas(PROFILE_AREA_QUEUE_FAMILIES_BIT);
+
+    VkQueueFamilyProperties2KHR props{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2};
+
+    props.queueFamilyProperties.queueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT;
+    props.queueFamilyProperties.queueCount = 2;
+    mock.AddQueueFamily({VK_STRUCT(props)});
+
+    props.queueFamilyProperties.queueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_PROTECTED_BIT;
+    props.queueFamilyProperties.queueCount = 1;
+    mock.AddQueueFamily({VK_STRUCT(props)});
+
+    VkBool32 supported = VK_TRUE;
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_FALSE);
+
+    std::vector<VpBlockProperties> block_properties(10);
+    uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+    supported = VK_TRUE;
+    result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                       &block_property_count, &block_properties[0]);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_FALSE);
+    EXPECT_EQ(block_property_count, 2);
+    EXPECT_STREQ(block_properties[0].blockName, "variant_a");
+    EXPECT_STREQ(block_properties[1].blockName, "variant_b");
+}
+
+TEST(mocked_api_generated_library, check_support_variants_format_success_1variant) {
     MockVulkanAPI mock;
 
     const VpProfileProperties profile{VP_LUNARG_TEST_VARIANTS_NAME, VP_LUNARG_TEST_VARIANTS_SPEC_VERSION};
@@ -886,4 +1343,851 @@ TEST(mocked_api_generated_library, check_support_variants_format_fail) {
     EXPECT_EQ(block_property_count, 2);
     EXPECT_STREQ(block_properties[0].blockName, "variant_a");
     EXPECT_STREQ(block_properties[1].blockName, "variant_b");
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_profile_reflection) {
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    VkResult result = VK_SUCCESS;
+    uint32_t video_profile_count = 0;
+    std::vector<VpVideoProfileProperties> props{};
+
+    const VpProfileProperties profileUnknown{"pouet", 1};
+    result = vpGetProfileVideoProfiles(&profileUnknown, nullptr, &video_profile_count, nullptr);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    result = vpGetProfileVideoProfiles(&profile, nullptr, &video_profile_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 3);
+
+    props.resize(video_profile_count);
+    result = vpGetProfileVideoProfiles(&profile, nullptr, &video_profile_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 3);
+
+    EXPECT_STREQ(props[0].name, "H.264 Decode (4:2:0 8-bit) Main progressive");
+    EXPECT_STREQ(props[1].name, "H.265 Decode (4:2:0 8-bit) Main");
+    EXPECT_STREQ(props[2].name, "H.265 Decode (4:2:0 10-bit) Main 10");
+
+    video_profile_count = 2;
+    props.clear();
+    props.resize(video_profile_count);
+
+    result = vpGetProfileVideoProfiles(&profile, nullptr, &video_profile_count, props.data());
+    EXPECT_EQ(result, VK_INCOMPLETE);
+    EXPECT_EQ(video_profile_count, 2);
+
+    EXPECT_STREQ(props[0].name, "H.264 Decode (4:2:0 8-bit) Main progressive");
+    EXPECT_STREQ(props[1].name, "H.265 Decode (4:2:0 8-bit) Main");
+
+    result = vpGetProfileVideoProfiles(&profile, "block", &video_profile_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 0);
+
+    result = vpGetProfileVideoProfiles(&profile, "variant_h264", &video_profile_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 1);
+
+    props.clear();
+    props.resize(video_profile_count);
+    result = vpGetProfileVideoProfiles(&profile, "variant_h264", &video_profile_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 1);
+
+    EXPECT_STREQ(props[0].name, "H.264 Decode (4:2:0 8-bit) Main progressive");
+
+    result = vpGetProfileVideoProfiles(&profile, "variant_h265", &video_profile_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 2);
+
+    props.clear();
+    props.resize(video_profile_count);
+    result = vpGetProfileVideoProfiles(&profile, "variant_h265", &video_profile_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_profile_count, 2);
+
+    EXPECT_STREQ(props[0].name, "H.265 Decode (4:2:0 8-bit) Main");
+    EXPECT_STREQ(props[1].name, "H.265 Decode (4:2:0 10-bit) Main 10");
+
+    result = vpGetProfileVideoProfiles(&profile, "variant_unknown", &video_profile_count, nullptr);
+    EXPECT_EQ(result, VK_INCOMPLETE);
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_profile_info_reflection) {
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    VkResult result = VK_SUCCESS;
+
+    VkVideoDecodeH264ProfileInfoKHR profile_info_h264{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR, nullptr};
+    VkVideoDecodeH265ProfileInfoKHR profile_info_h265{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR, &profile_info_h264};
+    VkVideoProfileInfoKHR profile_info{VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, &profile_info_h265};
+
+    auto clear_chain = [&] {
+        profile_info_h264 = VkVideoDecodeH264ProfileInfoKHR{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR, nullptr};
+        profile_info_h265 =
+            VkVideoDecodeH265ProfileInfoKHR{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR, &profile_info_h264};
+        profile_info = VkVideoProfileInfoKHR{VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, &profile_info_h265};
+    };
+
+    // H.264 Decode (4:2:0 8-bit) Main progressive
+
+    auto check_h264_main = [&] {
+        EXPECT_EQ(profile_info.videoCodecOperation, VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR);
+        EXPECT_EQ(profile_info.chromaSubsampling, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR);
+        EXPECT_EQ(profile_info.lumaBitDepth, VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR);
+        EXPECT_EQ(profile_info.chromaBitDepth, VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR);
+        EXPECT_EQ(profile_info_h264.stdProfileIdc, STD_VIDEO_H264_PROFILE_IDC_MAIN);
+        EXPECT_EQ(profile_info_h264.pictureLayout, VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR);
+    };
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, nullptr, 0, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h264_main();
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "block", 0, &profile_info);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "variant_h264", 0, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h264_main();
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "variant_h265", 0, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_NE(profile_info.videoCodecOperation, VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR);
+
+    // H.265 Decode (4:2:0 8-bit) Main
+
+    auto check_h265_main = [&] {
+        EXPECT_EQ(profile_info.videoCodecOperation, VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR);
+        EXPECT_EQ(profile_info.chromaSubsampling, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR);
+        EXPECT_EQ(profile_info.lumaBitDepth, VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR);
+        EXPECT_EQ(profile_info.chromaBitDepth, VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR);
+        EXPECT_EQ(profile_info_h265.stdProfileIdc, STD_VIDEO_H265_PROFILE_IDC_MAIN);
+    };
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, nullptr, 1, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main();
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "block", 0, &profile_info);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "variant_h264", 0, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_NE(profile_info.videoCodecOperation, VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR);
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "variant_h265", 0, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main();
+
+    // H.265 Decode (4:2:0 10-bit) Main 10
+
+    auto check_h265_main_10 = [&] {
+        EXPECT_EQ(profile_info.videoCodecOperation, VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR);
+        EXPECT_EQ(profile_info.chromaSubsampling, VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR);
+        EXPECT_EQ(profile_info.lumaBitDepth, VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR);
+        EXPECT_EQ(profile_info.chromaBitDepth, VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR);
+        EXPECT_EQ(profile_info_h265.stdProfileIdc, STD_VIDEO_H265_PROFILE_IDC_MAIN_10);
+    };
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, nullptr, 2, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main_10();
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "block", 2, &profile_info);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "variant_h264", 1, &profile_info);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoProfileInfo(&profile, "variant_h265", 1, &profile_info);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main_10();
+
+    // Structure types
+
+    uint32_t structure_type_count = 0;
+    std::vector<VkStructureType> structure_types{};
+
+    for (uint32_t i = 0; i < 3; ++i) {
+        result = vpGetProfileVideoProfileInfoStructureTypes(&profile, nullptr, i, &structure_type_count, nullptr);
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(structure_type_count, 2);
+
+        structure_types.clear();
+        structure_types.resize(structure_type_count);
+        result = vpGetProfileVideoProfileInfoStructureTypes(&profile, nullptr, i, &structure_type_count, structure_types.data());
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(structure_type_count, 2);
+
+        EXPECT_EQ(structure_types[0], VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR);
+        if (i == 0) {
+            EXPECT_EQ(structure_types[1], VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR);
+        } else {
+            EXPECT_EQ(structure_types[1], VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR);
+        }
+    }
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_capability_reflection) {
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    VkResult result = VK_SUCCESS;
+
+    VkVideoDecodeH264CapabilitiesKHR caps_h264{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR, nullptr};
+    VkVideoDecodeH265CapabilitiesKHR caps_h265{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR, &caps_h264};
+    VkVideoCapabilitiesKHR caps{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, &caps_h265};
+
+    auto clear_chain = [&] {
+        caps_h264 = VkVideoDecodeH264CapabilitiesKHR{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR, nullptr};
+        caps_h265 = VkVideoDecodeH265CapabilitiesKHR{VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR, &caps_h264};
+        caps = VkVideoCapabilitiesKHR{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, &caps_h265};
+    };
+
+    // H.264 Decode (4:2:0 8-bit) Main progressive
+
+    auto check_h264_main = [&] {
+        EXPECT_EQ(caps.maxCodedExtent.width, 1920);
+        EXPECT_EQ(caps.maxCodedExtent.height, 1080);
+        EXPECT_EQ(caps.maxDpbSlots, 17);
+        EXPECT_EQ(caps.maxActiveReferencePictures, 16);
+        EXPECT_EQ(caps_h264.maxLevelIdc, STD_VIDEO_H264_LEVEL_IDC_5_2);
+    };
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, nullptr, 0, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h264_main();
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "block", 0, &caps);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "variant_h264", 0, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h264_main();
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "variant_h265", 0, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(caps_h264.maxLevelIdc, 0);
+
+    // H.265 Decode (4:2:0 8-bit) Main
+
+    auto check_h265_main = [&] {
+        EXPECT_EQ(caps.maxCodedExtent.width, 3840);
+        EXPECT_EQ(caps.maxCodedExtent.height, 2160);
+        EXPECT_EQ(caps.maxDpbSlots, 8);
+        EXPECT_EQ(caps.maxActiveReferencePictures, 4);
+        EXPECT_EQ(caps_h265.maxLevelIdc, STD_VIDEO_H265_LEVEL_IDC_6_0);
+    };
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, nullptr, 1, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main();
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "block", 0, &caps);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "variant_h264", 0, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(caps_h265.maxLevelIdc, 0);
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "variant_h265", 0, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main();
+
+    // H.265 Decode (4:2:0 10-bit) Main 10
+
+    auto check_h265_main_10 = [&] {
+        EXPECT_EQ(caps.maxCodedExtent.width, 720);
+        EXPECT_EQ(caps.maxCodedExtent.height, 480);
+        EXPECT_EQ(caps.maxDpbSlots, 2);
+        EXPECT_EQ(caps.maxActiveReferencePictures, 1);
+        EXPECT_EQ(caps_h265.maxLevelIdc, STD_VIDEO_H265_LEVEL_IDC_5_0);
+    };
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, nullptr, 2, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main_10();
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "block", 2, &caps);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "variant_h264", 1, &caps);
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    clear_chain();
+    result = vpGetProfileVideoCapabilities(&profile, "variant_h265", 1, &caps);
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main_10();
+
+    // Structure types
+
+    uint32_t structure_type_count = 0;
+    std::vector<VkStructureType> structure_types{};
+
+    for (uint32_t i = 0; i < 3; ++i) {
+        result = vpGetProfileVideoCapabilityStructureTypes(&profile, nullptr, i, &structure_type_count, nullptr);
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(structure_type_count, 2);
+
+        structure_types.clear();
+        structure_types.resize(structure_type_count);
+        result = vpGetProfileVideoCapabilityStructureTypes(&profile, nullptr, i, &structure_type_count, structure_types.data());
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(structure_type_count, 2);
+
+        EXPECT_EQ(structure_types[0], VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR);
+        if (i == 0) {
+            EXPECT_EQ(structure_types[1], VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR);
+        } else {
+            EXPECT_EQ(structure_types[1], VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR);
+        }
+    }
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_format_reflection) {
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    VkResult result = VK_SUCCESS;
+
+    uint32_t video_format_count = 0;
+    std::vector<VkVideoFormatPropertiesKHR> props{};
+
+    // H.264 Decode (4:2:0 8-bit) Main progressive
+
+    auto check_h264_main = [&] {
+        EXPECT_EQ(video_format_count, 2);
+
+        EXPECT_EQ(props[0].format, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
+        EXPECT_EQ(props[0].imageCreateFlags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+        EXPECT_EQ(props[0].imageType, VK_IMAGE_TYPE_2D);
+        EXPECT_EQ(props[0].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+        EXPECT_EQ(props[1].format, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
+        EXPECT_EQ(props[1].imageCreateFlags, 0);
+        EXPECT_EQ(props[1].imageType, VK_IMAGE_TYPE_2D);
+        EXPECT_EQ(props[1].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR);
+    };
+
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 0, &video_format_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_format_count, 2);
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 0, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h264_main();
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, "block", 0, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    result = vpGetProfileVideoFormatProperties(&profile, "variant_h264", 0, &video_format_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_format_count, 2);
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, "variant_h264", 0, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h264_main();
+
+    // H.265 Decode (4:2:0 8-bit) Main
+
+    auto check_h265_main = [&] {
+        EXPECT_EQ(video_format_count, 2);
+
+        EXPECT_EQ(props[0].format, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
+        EXPECT_EQ(props[0].imageCreateFlags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+        EXPECT_EQ(props[0].imageType, VK_IMAGE_TYPE_2D);
+        EXPECT_EQ(props[0].imageUsageFlags,
+                  VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+        EXPECT_EQ(props[1].format, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
+        EXPECT_EQ(props[1].imageCreateFlags, 0);
+        EXPECT_EQ(props[1].imageType, VK_IMAGE_TYPE_2D);
+        EXPECT_EQ(props[1].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR | VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    };
+
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 1, &video_format_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_format_count, 2);
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 1, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main();
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, "block", 1, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    result = vpGetProfileVideoFormatProperties(&profile, "variant_h265", 0, &video_format_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_format_count, 2);
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, "variant_h265", 0, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main();
+
+    // H.265 Decode (4:2:0 10-bit) Main 10
+
+    auto check_h265_main_10 = [&] {
+        EXPECT_EQ(video_format_count, 1);
+
+        EXPECT_EQ(props[0].format, VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16);
+        EXPECT_EQ(props[0].imageCreateFlags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+        EXPECT_EQ(props[0].imageType, VK_IMAGE_TYPE_2D);
+        EXPECT_EQ(props[0].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR |
+                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    };
+
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 2, &video_format_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_format_count, 1);
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 2, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main_10();
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, "block", 2, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_ERROR_UNKNOWN);
+
+    result = vpGetProfileVideoFormatProperties(&profile, "variant_h265", 0, &video_format_count, nullptr);
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(video_format_count, 2);
+
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, "variant_h265", 1, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_SUCCESS);
+    check_h265_main_10();
+
+    // Incomplete
+
+    video_format_count = 1;
+    props.clear();
+    props.resize(video_format_count, {VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr});
+    result = vpGetProfileVideoFormatProperties(&profile, nullptr, 0, &video_format_count, props.data());
+    EXPECT_EQ(result, VK_INCOMPLETE);
+
+    EXPECT_EQ(props[0].format, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
+    EXPECT_EQ(props[0].imageCreateFlags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+    EXPECT_EQ(props[0].imageType, VK_IMAGE_TYPE_2D);
+    EXPECT_EQ(props[0].imageUsageFlags, VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                            VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_profile_success_2variants) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    initProfile(mock, profile);
+
+    VkBool32 supported = VK_FALSE;
+    VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_TRUE);
+
+    std::vector<VpBlockProperties> block_properties(10);
+    uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+    supported = VK_FALSE;
+    result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                       &block_property_count, &block_properties[0]);
+
+    EXPECT_EQ(result, VK_SUCCESS);
+    EXPECT_EQ(supported, VK_TRUE);
+
+    EXPECT_EQ(block_property_count, 2);
+    EXPECT_STREQ(block_properties[0].blockName, "block");
+    EXPECT_STREQ(block_properties[1].blockName, "variant_h264");
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_profile_success_1variant) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    VkVideoDecodeH264ProfileInfoKHR profile_info_h264{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR, nullptr};
+    profile_info_h264.stdProfileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
+    profile_info_h264.pictureLayout = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR;
+    VkVideoProfileInfoKHR profile_info{VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, &profile_info_h264};
+    profile_info.videoCodecOperation = VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR;
+    profile_info.chromaSubsampling = VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR;
+    profile_info.lumaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR;
+    profile_info.chromaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR;
+
+    // Missing capability
+    {
+        initProfile(mock, profile);
+        mock.RemoveVideoCapabilities(profile_info);
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_TRUE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_TRUE);
+
+        EXPECT_EQ(block_property_count, 2);
+        EXPECT_STREQ(block_properties[0].blockName, "block");
+        EXPECT_STREQ(block_properties[1].blockName, "variant_h265");
+    }
+
+    // Missing format
+    {
+        mock.ClearProfileAreas(PROFILE_AREA_ALL_BITS);
+        initProfile(mock, profile);
+        mock.RemoveVideoFormats(profile_info);
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_TRUE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_TRUE);
+
+        EXPECT_EQ(block_property_count, 2);
+        EXPECT_STREQ(block_properties[0].blockName, "block");
+        EXPECT_STREQ(block_properties[1].blockName, "variant_h265");
+    }
+}
+
+TEST(mocked_api_generated_library, check_support_variants_video_profile_fail) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_VIDEO_PROFILES_NAME, VP_RASTERGRID_TEST_VIDEO_PROFILES_SPEC_VERSION};
+
+    // Missing capability
+    {
+        initProfile(mock, profile);
+        mock.ClearProfileAreas(PROFILE_AREA_VIDEO_CAPABILITIES_BIT);
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 2);
+        EXPECT_STREQ(block_properties[0].blockName, "variant_h264");
+        EXPECT_STREQ(block_properties[1].blockName, "variant_h265");
+    }
+
+    // Missing format
+    {
+        mock.ClearProfileAreas(PROFILE_AREA_ALL_BITS);
+        initProfile(mock, profile);
+        mock.ClearProfileAreas(PROFILE_AREA_VIDEO_FORMATS_BIT);
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 2);
+        EXPECT_STREQ(block_properties[0].blockName, "variant_h264");
+        EXPECT_STREQ(block_properties[1].blockName, "variant_h265");
+    }
+}
+
+TEST(mocked_api_generated_library, check_support_wildcard_video_profiles) {
+    MockVulkanAPI mock;
+
+    const VpProfileProperties profile{VP_RASTERGRID_TEST_WILDCARD_VIDEO_PROFILES_NAME,
+                                      VP_RASTERGRID_TEST_WILDCARD_VIDEO_PROFILES_SPEC_VERSION};
+
+    initProfile(mock, profile);
+    mock.ClearProfileAreas(PROFILE_AREA_VIDEO_CAPABILITIES_BIT | PROFILE_AREA_VIDEO_FORMATS_BIT);
+
+    VkVideoDecodeH264ProfileInfoKHR h264_decode{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR, nullptr};
+    h264_decode.stdProfileIdc = STD_VIDEO_H264_PROFILE_IDC_MAIN;
+    h264_decode.pictureLayout = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR;
+
+    VkVideoProfileInfoKHR profile_info{VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, &h264_decode};
+    profile_info.videoCodecOperation = VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR;
+    profile_info.chromaSubsampling = VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR;
+    profile_info.lumaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR;
+    profile_info.chromaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR;
+
+    VulkanVideoProfile h264_decode_profile(&profile_info);
+
+    // No video profiles at all
+    {
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 3);
+        EXPECT_STREQ(block_properties[0].blockName, "general");
+        EXPECT_STREQ(block_properties[1].blockName, "decode_420_8bit");
+        EXPECT_STREQ(block_properties[2].blockName, "decode_h264");
+    }
+
+    // Add a 4:2:0 8-bit decode profile but without a sampleable decode output or extended usage support
+    {
+        VkVideoDecodeH264CapabilitiesKHR h264_decode_caps{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR, nullptr};
+        h264_decode_caps.maxLevelIdc = STD_VIDEO_H264_LEVEL_IDC_6_2;
+
+        VkVideoDecodeCapabilitiesKHR decode_caps{VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR, &h264_decode_caps};
+        decode_caps.flags = VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR;
+
+        VkVideoCapabilitiesKHR caps{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, &decode_caps};
+        caps.maxCodedExtent.width = 3840;
+        caps.maxCodedExtent.height = 2160;
+        caps.maxDpbSlots = 16;
+        caps.maxActiveReferencePictures = 15;
+
+        mock.AddVideoCapabilities(h264_decode_profile, {VK_STRUCT(caps), VK_STRUCT(decode_caps), VK_STRUCT(h264_decode_caps)});
+
+        VkVideoFormatPropertiesKHR dst_format{VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr};
+        dst_format.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+        dst_format.imageCreateFlags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
+        dst_format.imageType = VK_IMAGE_TYPE_2D;
+        dst_format.imageTiling = VK_IMAGE_TILING_LINEAR;
+        dst_format.imageUsageFlags = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR;
+
+        mock.AddVideoFormat(h264_decode_profile, {VK_STRUCT(dst_format)});
+
+        VkVideoFormatPropertiesKHR dpb_format{VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr};
+        dpb_format.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+        dpb_format.imageCreateFlags = 0;
+        dpb_format.imageType = VK_IMAGE_TYPE_2D;
+        dpb_format.imageTiling = VK_IMAGE_TILING_LINEAR;
+        dpb_format.imageUsageFlags = VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR;
+
+        mock.AddVideoFormat(h264_decode_profile, {VK_STRUCT(dpb_format)});
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 2);
+        EXPECT_STREQ(block_properties[0].blockName, "decode_420_8bit");
+        EXPECT_STREQ(block_properties[1].blockName, "decode_h264");
+    }
+
+    // Add another decode output format with the needed attributes, but triplanar, making it fail decode_420_8bit block check
+    {
+        VkVideoFormatPropertiesKHR dst_format{VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr};
+        dst_format.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
+        dst_format.imageCreateFlags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+        dst_format.imageType = VK_IMAGE_TYPE_2D;
+        dst_format.imageTiling = VK_IMAGE_TILING_OPTIMAL;
+        dst_format.imageUsageFlags = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_SAMPLED_BIT;
+
+        mock.AddVideoFormat(h264_decode_profile, {VK_STRUCT(dst_format)});
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 1);
+        EXPECT_STREQ(block_properties[0].blockName, "decode_420_8bit");
+    }
+
+    // Add another decode output format with extended usage support but not sampleable
+    {
+        VkVideoFormatPropertiesKHR dst_format{VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr};
+        dst_format.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+        dst_format.imageCreateFlags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+        dst_format.imageType = VK_IMAGE_TYPE_2D;
+        dst_format.imageTiling = VK_IMAGE_TILING_OPTIMAL;
+        dst_format.imageUsageFlags = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR;
+
+        mock.AddVideoFormat(h264_decode_profile, {VK_STRUCT(dst_format)});
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_TRUE);
+    }
+
+    // Change capabilities to lower DPB slots and references, making it fail decode_h264 block check
+    {
+        mock.RemoveVideoCapabilities(profile_info);
+
+        VkVideoDecodeH264CapabilitiesKHR h264_decode_caps{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR, nullptr};
+        h264_decode_caps.maxLevelIdc = STD_VIDEO_H264_LEVEL_IDC_6_2;
+
+        VkVideoDecodeCapabilitiesKHR decode_caps{VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR, &h264_decode_caps};
+        decode_caps.flags = VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR;
+
+        VkVideoCapabilitiesKHR caps{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, &decode_caps};
+        caps.maxCodedExtent.width = 3840;
+        caps.maxCodedExtent.height = 2160;
+        caps.maxDpbSlots = 15;
+        caps.maxActiveReferencePictures = 14;
+
+        mock.AddVideoCapabilities(h264_decode_profile, {VK_STRUCT(caps), VK_STRUCT(decode_caps), VK_STRUCT(h264_decode_caps)});
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 1);
+        EXPECT_STREQ(block_properties[0].blockName, "decode_h264");
+    }
+
+    // Finally, change the capabilities to fail the general block
+    {
+        mock.RemoveVideoCapabilities(profile_info);
+
+        VkVideoDecodeH264CapabilitiesKHR h264_decode_caps{VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR, nullptr};
+        h264_decode_caps.maxLevelIdc = STD_VIDEO_H264_LEVEL_IDC_6_2;
+
+        VkVideoDecodeCapabilitiesKHR decode_caps{VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR, &h264_decode_caps};
+        decode_caps.flags = VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR;
+
+        VkVideoCapabilitiesKHR caps{VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, &decode_caps};
+        caps.maxCodedExtent.width = 2048;
+        caps.maxCodedExtent.height = 1024;
+        caps.maxDpbSlots = 16;
+        caps.maxActiveReferencePictures = 15;
+
+        mock.AddVideoCapabilities(h264_decode_profile, {VK_STRUCT(caps), VK_STRUCT(decode_caps), VK_STRUCT(h264_decode_caps)});
+
+        VkBool32 supported = VK_FALSE;
+        VkResult result = vpGetPhysicalDeviceProfileSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        std::vector<VpBlockProperties> block_properties(10);
+        uint32_t block_property_count = static_cast<uint32_t>(block_properties.size());
+
+        supported = VK_FALSE;
+        result = vpGetPhysicalDeviceProfileVariantsSupport(mock.vkInstance, mock.vkPhysicalDevice, &profile, &supported,
+                                                           &block_property_count, &block_properties[0]);
+
+        EXPECT_EQ(result, VK_SUCCESS);
+        EXPECT_EQ(supported, VK_FALSE);
+
+        EXPECT_EQ(block_property_count, 1);
+        EXPECT_STREQ(block_properties[0].blockName, "general");
+    }
 }

--- a/profiles/test/data/VP_RASTERGRID_test_video_profiles.json
+++ b/profiles/test/data/VP_RASTERGRID_test_video_profiles.json
@@ -1,0 +1,948 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.0-204.json#",
+    "capabilities": {
+        "baseline": {
+            "extensions": {
+                "VK_KHR_video_queue": 1,
+                "VK_KHR_video_maintenance1": 1,
+                "VK_KHR_video_decode_queue": 1,
+                "VK_KHR_video_decode_h264": 1,
+                "VK_KHR_video_decode_h265": 1,
+                "VK_KHR_video_encode_queue": 1,
+                "VK_KHR_video_encode_h264": 1,
+                "VK_KHR_video_encode_h265": 1,
+                "VK_KHR_video_encode_quantization_map": 1
+            },
+            "formats": {
+                "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                        ],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                        ],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                        ],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR"
+                        ],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": []
+                    }
+                }
+            },
+            "videoProfiles": [
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH264ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H264_PROFILE_IDC_BASELINE",
+                            "pictureLayout": "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 1920,
+                                "height": 1080
+                            }
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH264ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H264_PROFILE_IDC_MAIN",
+                            "pictureLayout": "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 1280,
+                                "height": 720
+                            }
+                        },
+                        "VkVideoDecodeH264CapabilitiesKHR": {
+                            "fieldOffsetGranularity": {
+                                "x": 48,
+                                "y": 16
+                            }
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 3840,
+                                "height": 2160
+                            }
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoDecodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN_10"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 2560,
+                                "height": 1440
+                            }
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeH264ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H264_PROFILE_IDC_BASELINE"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 1920,
+                                "height": 1080
+                            }
+                        },
+                        "VkVideoEncodeH264CapabilitiesKHR": {
+                            "maxSliceCount": 4
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeH264ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H264_PROFILE_IDC_MAIN"
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeH265CapabilitiesKHR": {
+                            "maxSliceSegmentCount": 3
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR",
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN_10"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 1280,
+                                "height": 720
+                            }
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxDpbSlots": 17,
+                            "maxActiveReferencePictures": 16
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoDecodeH264ProfileInfoKHR": {
+                            "pictureLayout": "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxDpbSlots": 33,
+                            "maxActiveReferencePictures": 32
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxDpbSlots": 17,
+                            "maxActiveReferencePictures": 16
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeH264CapabilitiesKHR": {
+                            "maxSliceCount": 1
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeH265CapabilitiesKHR": {
+                            "maxSliceSegmentCount": 1
+                        }
+                    }
+                },
+                {
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxDpbSlots": 2,
+                            "maxActiveReferencePictures": 1
+                        },
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "maxRateControlLayers": 1
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeH264CapabilitiesKHR": {
+                            "flags": [
+                                "VK_VIDEO_ENCODE_H264_CAPABILITY_GENERATE_PREFIX_NALU_BIT_KHR"
+                            ],
+                            "maxPPictureL0ReferenceCount": 1
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoEncodeH264ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H264_PROFILE_IDC_MAIN"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeH264CapabilitiesKHR": {
+                            "maxPPictureL0ReferenceCount": 2
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoEncodeH265ProfileInfoKHR": {
+                            "stdProfileIdc": "STD_VIDEO_H265_PROFILE_IDC_MAIN"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxDpbSlots": 3,
+                            "maxActiveReferencePictures": 2
+                        },
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "flags": [
+                                "VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeH265CapabilitiesKHR": {
+                            "maxBPictureL0ReferenceCount": 1,
+                            "maxL1ReferenceCount": 1
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_LINEAR",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_OPTIMAL",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "chromaSubsampling": [
+                                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR"
+                            ],
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ],
+                            "chromaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR"
+                            ]
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_LINEAR",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "capabilities": {
+                        "VkVideoDecodeCapabilitiesKHR": {}
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_OPTIMAL",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "capabilities": {
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "flags": [
+                                "VK_VIDEO_ENCODE_CAPABILITY_EMPHASIS_MAP_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeQuantizationMapCapabilitiesKHR": {
+                            "maxQuantizationMapExtent": {
+                                "width": 64,
+                                "height": 64
+                            }
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_OPTIMAL",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_R8_UNORM",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_LINEAR",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR"
+                                ]
+                            },
+                            "VkVideoFormatQuantizationMapPropertiesKHR": {
+                                "quantizationMapTexelSize": {
+                                    "width": 64,
+                                    "height": 64
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "flags": [
+                                "VK_VIDEO_ENCODE_CAPABILITY_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeQuantizationMapCapabilitiesKHR": {
+                            "maxQuantizationMapExtent": {
+                                "width": 256,
+                                "height": 256
+                            }
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_R8_SINT",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_LINEAR",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                                ]
+                            },
+                            "VkVideoFormatQuantizationMapPropertiesKHR": {
+                                "quantizationMapTexelSize": {
+                                    "width": 16,
+                                    "height": 16
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR",
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "flags": [
+                                "VK_VIDEO_ENCODE_CAPABILITY_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                            ]
+                        },
+                        "VkVideoEncodeQuantizationMapCapabilitiesKHR": {
+                            "maxQuantizationMapExtent": {
+                                "width": 192,
+                                "height": 128
+                            }
+                        }
+                    },
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_R32_SINT",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_LINEAR",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                                ]
+                            },
+                            "VkVideoFormatQuantizationMapPropertiesKHR": {
+                                "quantizationMapTexelSize": {
+                                    "width": 16,
+                                    "height": 16
+                                }
+                            },
+                            "VkVideoFormatH265QuantizationMapPropertiesKHR": {
+                                "compatibleCtbSizes": [
+                                    "VK_VIDEO_ENCODE_H265_CTB_SIZE_16_BIT_KHR"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "format": "VK_FORMAT_R32_SINT",
+                                "componentMapping": {
+                                    "r": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "g": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "b": "VK_COMPONENT_SWIZZLE_IDENTITY",
+                                    "a": "VK_COMPONENT_SWIZZLE_IDENTITY"
+                                },
+                                "imageType": "VK_IMAGE_TYPE_2D",
+                                "imageTiling": "VK_IMAGE_TILING_LINEAR",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"
+                                ]
+                            },
+                            "VkVideoFormatQuantizationMapPropertiesKHR": {
+                                "quantizationMapTexelSize": {
+                                    "width": 32,
+                                    "height": 32
+                                }
+                            },
+                            "VkVideoFormatH265QuantizationMapPropertiesKHR": {
+                                "compatibleCtbSizes": [
+                                    "VK_VIDEO_ENCODE_H265_CTB_SIZE_16_BIT_KHR",
+                                    "VK_VIDEO_ENCODE_H265_CTB_SIZE_32_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "minBitstreamBufferOffsetAlignment": 4096,
+                            "minBitstreamBufferSizeAlignment": 4096,
+                            "maxCodedExtent": {
+                                "height": 1024
+                            }
+                        }
+                    }
+                },
+                {
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "maxCodedExtent": {
+                                "width": 960
+                            }
+                        },
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "flags": [
+                                "VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "minBitstreamBufferOffsetAlignment": 256
+                        },
+                        "VkVideoDecodeH264CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H264_LEVEL_IDC_5_0"
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoDecodeH264ProfileInfoKHR": {
+                            "pictureLayout": "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoDecodeH264CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H264_LEVEL_IDC_6_1"
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR"
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoDecodeH265CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H265_LEVEL_IDC_4_1"
+                        }
+                    }
+                },
+                {
+                    "profile": {
+                        "VkVideoProfileInfoKHR": {
+                            "videoCodecOperation": "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_KHR",
+                            "lumaBitDepth": [
+                                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR"
+                            ]
+                        }
+                    },
+                    "capabilities": {
+                        "VkVideoCapabilitiesKHR": {
+                            "minBitstreamBufferOffsetAlignment": 1024
+                        },
+                        "VkVideoDecodeH265CapabilitiesKHR": {
+                            "maxLevelIdc": "STD_VIDEO_H265_LEVEL_IDC_5_0"
+                        }
+                    }
+                },
+                {
+                    "capabilities": {
+                        "VkVideoEncodeCapabilitiesKHR": {
+                            "supportedEncodeFeedbackFlags": [
+                                "VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR",
+                                "VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageCreateFlags": [
+                                    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT",
+                                    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"
+                                ],
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageCreateFlags": [
+                                    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT",
+                                    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"
+                                ],
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_SAMPLED_BIT",
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "formats": [
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR",
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR",
+                                    "VK_IMAGE_USAGE_TRANSFER_DST_BIT",
+                                    "VK_IMAGE_USAGE_TRANSFER_SRC_BIT"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageTiling": "VK_IMAGE_TILING_OPTIMAL",
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR",
+                                    "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR",
+                                    "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
+                                ]
+                            }
+                        },
+                        {
+                            "VkVideoFormatPropertiesKHR": {
+                                "imageUsageFlags": [
+                                    "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR",
+                                    "VK_IMAGE_USAGE_TRANSFER_SRC_BIT"
+                                ]
+                            },
+                            "VkVideoFormatQuantizationMapPropertiesKHR": {
+                                "quantizationMapTexelSize": {
+                                    "width": 16,
+                                    "height": 16
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "profiles": {
+        "VP_RASTERGRID_test_video_profiles": {
+            "version": 1,
+            "api-version": "1.3.300",
+            "label": "Video profiles unit test",
+            "description": "For unit testing video profile capability and format queries",
+            "contributors": {
+                "Daniel Rakos": {
+                    "company": "RasterGrid",
+                    "email": "daniel.rakos@rastergrid.com",
+                    "github": "aqnuep",
+                    "contact": true
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2024-11-20",
+                    "author": "Daniel Rakos",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "baseline"
+            ]
+        }
+    }
+}

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,6 @@
 # ~~~
 # Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -135,6 +136,8 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
     target_compile_options(VulkanCompilerConfigurationExtra INTERFACE
         -Wno-unused-function
         -Wno-missing-field-initializers
+        -Wno-type-limits    # Disable warning '>=': expression is always true
+        -Wno-extra-semi     # Disable warning about extra semicolons (used by many tests today)
     )
 elseif(MSVC)
     target_compile_options(VulkanCompilerConfigurationExtra INTERFACE

--- a/scripts/gen_profiles_tests.py
+++ b/scripts/gen_profiles_tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (c) 2021-2024 LunarG, Inc.
+# Copyright (c) 2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 # you may not use this file except in compliance with the License.
@@ -106,7 +107,8 @@ class TestsCapabilitiesGenerated : public VkTestFramework {
         const char* profile_name_data = "VP_LUNARG_test_api";
         VkBool32 emulate_portability_data = VK_TRUE;
         const std::vector<const char*> simulate_capabilities = {
-            "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT", "SIMULATE_EXTENSIONS_BIT", "SIMULATE_FORMATS_BIT", "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT"};
+            "SIMULATE_API_VERSION_BIT", "SIMULATE_FEATURES_BIT", "SIMULATE_PROPERTIES_BIT", "SIMULATE_EXTENSIONS_BIT", "SIMULATE_FORMATS_BIT",
+            "SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT", "SIMULATE_VIDEO_CAPABILITIES_BIT", "SIMULATE_VIDEO_FORMATS_BIT"};
         const std::vector<const char*> debug_reports = {
             "DEBUG_REPORT_ERROR_BIT"};
 


### PR DESCRIPTION
This PR adds support for defining video profiles and corresponding video capabilities and video format properties in the profile JSONs.

The change adds this support to the following components (through codegen):

- Vulkan Profiles schema
- Vulkan Profiles documentation
- Vulkan Profiles Library
- Vulkan Profiles Layer

In addition, this also adds back support for queue family properties in the Vulkan Profiles Library which was removed at some point.