### PR TITLE
profiles: Fix DRM format handling

### DIFF
--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -2808,10 +2808,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
         }
     }
 
-    dt->GetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties);
-    return GetPhysicalDeviceImageFormatProperties(physicalDevice, pImageFormatInfo->format, pImageFormatInfo->type,
-                                                  pImageFormatInfo->tiling, pImageFormatInfo->usage, pImageFormatInfo->flags,
-                                                  &pImageFormatProperties->imageFormatProperties);
+    return dt->GetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2(VkPhysicalDevice physicalDevice,


### PR DESCRIPTION
`vkGetPhysicalDeviceImageFormatProperties2KHR()` accidentally ignored `pNext->VkPhysicalDeviceImageDrmFormatModifierInfoEXT` as it calls `GetPhysicalDeviceImageFormatProperties()` instead of the `2` variant of the function. This is against [VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetPhysicalDeviceImageFormatProperties.html#VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248) so fix that by calling `vkGetPhysicalDeviceImageFormatProperties2()`.

Previously the result of `dt->GetPhysicalDeviceImageFormatProperties2` was also being ignored and I think the intention was to do this anyway looking at the code.

Came across this when I was using the profile layer with a game which would segfault in Turnip since this was violating the Vulkan spec and Turnip tried to find/use `VkPhysicalDeviceImageDrmFormatModifierInfoEXT`.