### PR TITLE
Delay some requirements that Mali Bifrost chipsets cannot do

### DIFF
--- a/profiles/VP_ANDROID_16_minimums.json
+++ b/profiles/VP_ANDROID_16_minimums.json
@@ -50,7 +50,6 @@
                     "limits": {
                         "bufferImageGranularity": 4096,
                         "lineWidthGranularity": 0.5,
-                        "maxBoundDescriptorSets": 7,
                         "maxColorAttachments": 8,
                         "maxComputeWorkGroupInvocations": 256,
                         "maxComputeWorkGroupSize": [ 256, 256, 64 ],
@@ -63,7 +62,6 @@
                         "maxFragmentCombinedOutputResources": 16,
                         "maxPerStageDescriptorUniformBuffers": 15,
                         "maxPerStageResources": 200,
-                        "maxPushConstantsSize": 256,
                         "maxSamplerLodBias": 14,
                         "maxUniformBufferRange": 65536,
                         "maxVertexOutputComponents": 128,
@@ -79,7 +77,7 @@
                     "shaderSignedZeroInfNanPreserveFloat32": true
                 },
                 "VkPhysicalDeviceVulkan11Properties": {
-                    "subgroupSupportedStages": ["VK_SHADER_STAGE_FRAGMENT_BIT", "VK_SHADER_STAGE_COMPUTE_BIT"]
+                    "subgroupSupportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
                 }
             }
         },
@@ -125,6 +123,12 @@
                     "date": "2024-11-15",
                     "author": "Ian Elliott",
                     "comment": "Delay some requirements that Mali Bifrost chipsets cannot do"
+                },
+                {
+                    "revision": 4,
+                    "date": "2024-12-10",
+                    "author": "Ian Elliott",
+                    "comment": "Delay some requirements that Adreno A6xx chipsets cannot do"
                 }
             ],
             "profiles": [


### PR DESCRIPTION
We are delaying 3 VPA16 items to VPA17 because the Adreno A6xx-based SoCs cannot do them.