### PR TITLE
profiles: Add option to load unknown features from driver

### DIFF
--- a/layer/VkLayer_khronos_profiles.json.in
+++ b/layer/VkLayer_khronos_profiles.json.in
@@ -305,12 +305,32 @@
                                         {
                                             "key": "DEFAULT_FEATURE_VALUES_DEVICE",
                                             "label": "Use Device Values",
-                                            "description": "When a feature is not mentionned in the select Vulkan profiles, set is to the physical device value."
+                                            "description": "When a feature is not mentioned in the select Vulkan profiles, set is to the physical device value."
                                         },
                                         {
                                             "key": "DEFAULT_FEATURE_VALUES_FALSE",
                                             "label": "Use False",
-                                            "description": "When a feature is not mentionned in the select Vulkan profiles, set it to false."
+                                            "description": "When a feature is not mentioned in the select Vulkan profiles, set it to false."
+                                        }
+                                    ]
+                                },
+                                {
+                                    "key": "unknown_feature_values",
+                                    "label": "Unknown Features",
+                                    "description": "Feature values when unrecongnized by Vulkan profiles.",
+                                    "status": "STABLE",
+                                    "type": "ENUM",
+                                    "default": "UNKNOWN_FEATURE_VALUES_UNCHANGED",
+                                    "flags": [
+                                        {
+                                            "key": "UNKNOWN_FEATURE_VALUES_UNCHANGED",
+                                            "label": "Unmodified",
+                                            "description": "When a feature is not recognized by Vulkan profiles, skip it."
+                                        },
+                                        {
+                                            "key": "UNKNOWN_FEATURE_VALUES_DEVICE",
+                                            "label": "Use Device Values",
+                                            "description": "When a feature is not recognized by Vulkan profiles, attempt to load device values."
                                         }
                                     ]
                                 }

--- a/layer/profiles.h
+++ b/layer/profiles.h
@@ -71,6 +71,7 @@ std::string GetDebugReportsLog(DebugActionFlags flags);
 #define kLayerSettingsExcludeDeviceExtensions "exclude_device_extensions"
 #define kLayerSettingsExcludeFormats "exclude_formats"
 #define kLayerSettingsDefaultFeatureValues "default_feature_values"
+#define kLayerSettingsUnknownFeatureValues "unknown_feature_values"
 #define kLayerSettingsForceDevice "force_device"
 #define kLayerSettingsForceDeviceUUID "force_device_uuid"
 #define kLayerSettingsForceDeviceName "force_device_name"

--- a/layer/profiles_settings.cpp
+++ b/layer/profiles_settings.cpp
@@ -245,6 +245,7 @@ void InitProfilesLayerSettings(const VkInstanceCreateInfo *pCreateInfo, const Vk
                                               kLayerSettingsExcludeDeviceExtensions,
                                               kLayerSettingsExcludeFormats,
                                               kLayerSettingsDefaultFeatureValues,
+                                              kLayerSettingsUnknownFeatureValues,
                                               kLayerSettingsForceDevice,
                                               kLayerSettingsForceDeviceUUID,
                                               kLayerSettingsForceDeviceName};
@@ -305,6 +306,12 @@ void InitProfilesLayerSettings(const VkInstanceCreateInfo *pCreateInfo, const Vk
             vkuGetLayerSettingValue(layerSettingSet, kLayerSettingsDefaultFeatureValues, value);
             layer_settings->simulate.default_feature_values = GetDefaultFeatureValues(ToUpper(value));
         }
+    }
+
+    if (vkuHasLayerSetting(layerSettingSet, kLayerSettingsUnknownFeatureValues)) {
+        std::string value;
+        vkuGetLayerSettingValue(layerSettingSet, kLayerSettingsUnknownFeatureValues, value);
+        layer_settings->simulate.unknown_feature_values = GetUnknownFeatureValues(ToUpper(value));
     }
 
     if (vkuHasLayerSetting(layerSettingSet, kLayerSettingsExcludeDeviceExtensions)) {
@@ -461,6 +468,7 @@ void InitProfilesLayerSettings(const VkInstanceCreateInfo *pCreateInfo, const Vk
     const std::string profile_dirs = GetString(layer_settings->simulate.profile_dirs);
     const std::string simulation_capabilities_log = GetSimulateCapabilitiesLog(layer_settings->simulate.capabilities);
     const std::string default_feature_values = GetDefaultFeatureValuesString(layer_settings->simulate.default_feature_values);
+    const std::string unknown_feature_values = GetUnknownFeatureValuesString(layer_settings->simulate.unknown_feature_values);
     const std::string debug_actions_log = GetDebugActionsLog(layer_settings->log.debug_actions);
     const std::string debug_reports_log = GetDebugReportsLog(layer_settings->log.debug_reports);
 
@@ -473,6 +481,7 @@ void InitProfilesLayerSettings(const VkInstanceCreateInfo *pCreateInfo, const Vk
         format("\t%s: %s\n", kLayerSettingsProfileValidation, layer_settings->simulate.profile_validation ? "true" : "false");
     settings_log += format("\t%s: %s\n", kLayerSettingsSimulateCapabilities, simulation_capabilities_log.c_str());
     settings_log += format("\t%s: %s\n", kLayerSettingsDefaultFeatureValues, default_feature_values.c_str());
+    settings_log += format("\t%s: %s\n", kLayerSettingsUnknownFeatureValues, unknown_feature_values.c_str());
 
     settings_log +=
         format("\t%s: %s\n", kLayerSettingsEmulatePortability, layer_settings->simulate.emulate_portability ? "true" : "false");

--- a/layer/profiles_settings.h
+++ b/layer/profiles_settings.h
@@ -122,7 +122,6 @@ enum DefaultFeatureValues {
     DEFAULT_FEATURE_VALUES_DEVICE
 };
 
-
 static DefaultFeatureValues GetDefaultFeatureValues(const std::string &value) {
     if (value == "DEFAULT_FEATURE_VALUES_FALSE") {
         return DEFAULT_FEATURE_VALUES_FALSE;
@@ -141,6 +140,31 @@ static std::string GetDefaultFeatureValuesString(DefaultFeatureValues value) {
     }
 
     return "DEFAULT_FEATURE_VALUES_DEVICE";
+}
+
+enum UnknownFeatureValues {
+    UNKNOWN_FEATURE_VALUES_UNCHANGED = 0,
+    UNKNOWN_FEATURE_VALUES_DEVICE
+};
+
+static UnknownFeatureValues GetUnknownFeatureValues(const std::string &value) {
+    if (value == "UNKNOWN_FEATURE_VALUES_UNCHANGED") {
+        return UNKNOWN_FEATURE_VALUES_UNCHANGED;
+    } else if (value == "UNKNOWN_FEATURE_VALUES_DEVICE") {
+        return UNKNOWN_FEATURE_VALUES_DEVICE;
+    }
+
+    return UNKNOWN_FEATURE_VALUES_UNCHANGED;
+}
+
+static std::string GetUnknownFeatureValuesString(UnknownFeatureValues value) {
+    if (value == UNKNOWN_FEATURE_VALUES_UNCHANGED) {
+        return "UNKNOWN_FEATURE_VALUES_UNCHANGED";
+    } else if (value == UNKNOWN_FEATURE_VALUES_DEVICE) {
+        return "UNKNOWN_FEATURE_VALUES_DEVICE";
+    }
+
+    return "UNKNOWN_FEATURE_VALUES_UNCHANGED";
 }
 
 enum ForceDevice {
@@ -165,6 +189,7 @@ struct ProfileLayerSettings {
         bool profile_validation{false};
         SimulateCapabilityFlags capabilities{SIMULATE_API_VERSION_BIT | SIMULATE_FEATURES_BIT | SIMULATE_PROPERTIES_BIT};
         DefaultFeatureValues default_feature_values{DEFAULT_FEATURE_VALUES_DEVICE};
+        UnknownFeatureValues unknown_feature_values{UNKNOWN_FEATURE_VALUES_UNCHANGED};
         std::vector<std::string> exclude_device_extensions;
         std::vector<std::string> exclude_formats;
         bool emulate_portability{true};

--- a/scripts/gen_profiles_layer.py
+++ b/scripts/gen_profiles_layer.py
@@ -2542,6 +2542,10 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2(VkPhysicalDevice physicalD
 
     PhysicalDeviceData *pdd = PhysicalDeviceData::Find(physicalDevice);
     if (pdd) {
+        ProfileLayerSettings *layer_settings = &JsonLoader::Find(pdd->instance())->layer_settings;
+        if (layer_settings->simulate.unknown_feature_values == UNKNOWN_FEATURE_VALUES_DEVICE) {
+            dt->GetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
+        }
         FillPNextChain(pdd, pFeatures->pNext);
     } else {
         dt->GetPhysicalDeviceFeatures2(physicalDevice, pFeatures);


### PR DESCRIPTION
The new option allows to first load all the features from a driver, so if the vulkan profiles does not know about a features struct and will not write to it, then it will have the device values

Closes #775