### PR TITLE
profiles: Handle empty video profile name suffix nicer

### DIFF
--- a/scripts/gen_profiles_solution.py
+++ b/scripts/gen_profiles_solution.py
@@ -5999,7 +5999,8 @@ VPAPI_ATTR void vpForEachMatchingVideoProfiles(
                     newProfiles = {}
                     for profileStructMemberValue, profileStructMemberName in profileStructMember.values.items():
                         for profileName, profile in profiles.items():
-                            newProfileName = f'{profileName} {profileStructMemberName}'
+                            # Only add video profile name suffix to the full descriptive name if not empty to avoid excess whitespace
+                            newProfileName = profileName if profileStructMemberName == '' else f'{profileName} {profileStructMemberName}'
                             newProfiles[newProfileName] = profile + [{
                                 "struct": profileStruct.struct,
                                 "member": profileStructMember.name,


### PR DESCRIPTION
In case the descriptive name corresponding to a `<videoprofilemember>` construct is empty, then avoid stacking space characters in the full descriptive name of the video profile.