### PR TITLE
Add logging tag to android logging

### DIFF
--- a/scripts/gen_profiles_solution.py
+++ b/scripts/gen_profiles_solution.py
@@ -99,7 +99,7 @@ DEBUG_MSG_CB_DEFINE = '''
 #if defined(ANDROID) || defined(__ANDROID__)
 #include <android/log.h>
 #define VP_DEBUG_MESSAGE_CALLBACK(MSG) \\
-    __android_log_print(ANDROID_LOG_ERROR, "Profiles ERROR", "%s", MSG)
+    __android_log_print(ANDROID_LOG_ERROR, "vkprofiles Profiles ERROR", "%s", MSG)
 #else
 #define VP_DEBUG_MESSAGE_CALLBACK(MSG) fprintf(stderr, "%s\\n", MSG)
 #endif


### PR DESCRIPTION
Add logcat tag "vkprofiles". it's convenient to do adb logcat -s vkprofiles to see all vulkan profile related logs.