### PR TITLE
scripts: Remove useless VulkanHeaders cmake option

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,9 +6,7 @@
             "sub_dir": "Vulkan-Headers",
             "build_dir": "Vulkan-Headers/build",
             "install_dir": "Vulkan-Headers/build/install",
-            "cmake_options": [
-                "-DVULKAN_HEADERS_ENABLE_MODULE=OFF"
-            ],
+            "cmake_options": [],
             "commit": "v1.4.326"
         },
         {


### PR DESCRIPTION
Modules are defaulted to off, so setting it manually isn't necessary.