### PR TITLE
profiles: Add profiles convert script infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install jsonschema
         run: python3 -m pip install jsonschema
       - name: Install Dependencies
@@ -66,6 +66,11 @@ jobs:
         run: cmake --build build --config ${{matrix.config}}
       - name: Install
         run: cmake --install build --prefix build/install --config ${{matrix.config}}
+      - name: Python Unit Tests
+        run: |
+          pip install vulkan-object
+          python -m unittest -v scripts/tests/test_util.py
+          python -m unittest -v scripts/tests/test_json.py
 
   android:
     env:
@@ -107,18 +112,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, Win32 ]
+        arch: [ x64 ]
         config: [ debug, release ]
-        exclude:
-          - arch: Win32
-            config: release
-          - arch: x64
-            config: debug
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install jsonschema
         run: python3 -m pip install jsonschema
       - uses: lukka/get-cmake@latest
@@ -131,3 +131,8 @@ jobs:
         run: cmake --build build --config ${{matrix.config}}
       - name: Install
         run: cmake --install build --prefix build/install --config ${{matrix.config}}
+      - name: Python Unit Tests
+        run: |
+          python -m pip install vulkan-object
+          python -m unittest -v scripts/tests/test_util.py
+          python -m unittest -v scripts/tests/test_json.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 # Release Notes
 
+## [Vulkan Profiles Tools 1.4.3XX](https://github.com/KhronosGroup/Vulkan-Profiles/tree/main) - July 2026
+
+### Bugfixes:
+- Fix profiles schema of generated profiles file with `gen_profiles_file.py` and using `--config`
+
 ## [Vulkan Profiles Tools 1.4.350](https://github.com/KhronosGroup/Vulkan-Profiles/tree/sdk-1.4.350.0) - May 2026
 
 ### Features:

--- a/scripts/gen_profiles_file.py
+++ b/scripts/gen_profiles_file.py
@@ -140,7 +140,7 @@ class ProfileConfig():
                             self.input_profile_values.append(json_file['profiles'][profile])
                             self.input_profile_names.append(profile)
         else:
-            print('ERROR: Not input directory set, use --input')
+            print('ERROR: No input directory set, use --input')
             exit()
 
     def get_api_version(self, profiles, merge_mode):
@@ -998,8 +998,8 @@ if __name__ == '__main__':
         json_file = open(args.config, "r")
         json_data = json.load(json_file)
 
-        if json_data["$schema"]:
-            profile_file.set_schema(json_data["$schema"])
+        #if json_data["$schema"]:
+        #    profile_file.set_schema(json_data["$schema"])
         if json_data["contributors"]:
             profile_file.set_contributors(json_data["contributors"])
         if json_data["history"]:

--- a/scripts/profiles.py
+++ b/scripts/profiles.py
@@ -1,0 +1,235 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2026-2026 Google, Inc.
+# Copyright (C) 2026-2026 Valve Corporation
+# Copyright (c) 2026-2026 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: 
+# - Christophe Riccio <christophe@lunarg.com>
+
+from datetime import datetime
+from pathlib import Path
+import argparse
+import functools
+import importlib.resources
+import json
+import re
+import tempfile
+import os
+import sys
+import collections
+from vulkan_object import get_vulkan_object
+
+def load_profiles_jsons(input_dir):
+    if not isinstance(input_dir, Path):
+        print('ERROR: No `input_dir` is not a Path type')
+        exit()
+    if input_dir is None:
+        print('ERROR: No input directory set, use --input')
+        exit()
+
+    profiles_files_paths = []
+    for pos_json in os.listdir(input_dir):
+        if pos_json.endswith('.json'):
+            full_path = input_dir / pos_json
+            profiles_files_paths.append(full_path)
+
+    json_files_dict = {}
+
+    # Load the json files in the directory
+    for i in range(len(profiles_files_paths)):
+        with open(profiles_files_paths[i], "r", encoding="utf-8") as file:
+            json_file_data = json.load(file)
+
+            # Check the schema start with "https://schema.khronos.org/vulkan/profiles-0.8.", otherwise it's not a profiles file (or a valid one)
+            if isinstance(json_file_data, dict) and "$schema" in json_file_data:
+                schema_url = json_file_data["$schema"]
+
+                if isinstance(schema_url, str) and schema_url.startswith("https://schema.khronos.org/vulkan/profiles-0.8"):
+                    print(f"[DEBUG] Loading: {profiles_files_paths[i]}")
+                    json_files_dict[profiles_files_paths[i]] = json_file_data
+
+    return json_files_dict
+
+def save_profiles_jsons(output_dir, json_files_dict):
+    if not isinstance(output_dir, Path):
+        print('ERROR: `output_dir` is not a Path type')
+        exit()
+    if output_dir is None:
+        print('ERROR: No output directory set, use --output')
+        exit()
+    if not output_dir.exists():
+        print(f"ERROR: {output_dir} doesn't exist")
+        exit()
+    if not output_dir.is_dir():
+        print(f'ERROR: {output_dir} is not a directory')
+        exit()
+    
+    for key, value in json_files_dict.items():
+        output_file = output_dir / key.name
+        with open(output_file, "w", encoding="utf-8") as file:
+            json.dump(value, file, indent=4)
+
+def main_convert(args):
+    vk = get_vulkan_object()
+
+    for version in vk.versions.values():
+        print(version.name)
+    
+    json_files_dict = load_profiles_jsons(Path(args.input))
+    
+    save_profiles_jsons(Path(args.output), json_files_dict)
+ 
+def main(argv):
+    parser = argparse.ArgumentParser(description='Convert Vulkan profile JSON file')
+    parser.add_argument('convert', action='store',
+                        help='Convert an implicit profile to an explicit profile by pulling Vulkan capabilities dependencies from vk.xml.')
+    parser.add_argument('--registry', '-r', action='store', # required=True,
+                        help='Use specified registry file instead of vk.xml.')
+#    parser.add_argument('--config', '-c', action='store',
+#                        help='Use specified a JSON merge config file path instead of using individual arguments.')
+    parser.add_argument('--input', '-i', action='store', required=True, help='Path to the input profiles files.')
+    parser.add_argument('--output', '-o', action='store', required=True, help='Path to the output profiles files.')
+#    parser.add_argument('--output-profile', action='store',
+#                        help='Profile name of the output profile. Deprecated, replaced by `--profile-name`.')
+#    parser.add_argument('--profile-name', action='store',
+#                        help='Profile name of the output profile. If the argument is not set, the value is generated.')
+#    parser.add_argument('--profile-version', action='store',
+#                        help='Override the Profile version of the generated profile. If the argument is not set, the value is 1.')
+#    parser.add_argument('--profile-label', action='store',
+#                        help='Override the Label of the generated profile. If the argument is not set, the value is generated.')
+#    parser.add_argument('--profile-desc', action='store',
+#                        help='Override the Description of the generated profile. If the argument is not set, the value is generated.')
+#    parser.add_argument('--profile-date', action='store',
+#                        help='Override the release date of the generated profile. If the argument is not set, the value is generated.')
+#    parser.add_argument('--profile-api-version', action='store',
+#                        help='Override the Vulkan API version of the generated profile. If the argument is not set, the value is generated.')
+#    parser.add_argument('--profile-stage', action='store', choices=['ALPHA', 'BETA', 'STABLE'], default='STABLE',
+#                        help='Override the development stage of the generated profile. If the argument is not set, the value is set to "stable".')
+#    parser.add_argument('--profile-required-profiles', action='store',
+#                        help='Comma separated list of required profiles by the generated profile.')
+#    parser.add_argument('--mode', '-m', action='store', choices=['union', 'intersection'], default='intersection',
+#                        help='Mode of profile combination. If the argument is not set, the value is set to "intersection".')
+#    parser.add_argument('--strip-duplicate-structs', action='store_true',
+#                        help='Strip the duplicated structures in the generated profiles file.')
+
+    # parser.set_defaults(mode='intersection')
+
+    args = parser.parse_args(argv)
+
+    if args.convert is not None:
+        main_convert(args)
+        exit()
+    else:
+        parser.print_help()
+        exit()
+
+    # profile_configs = list()
+
+    # if args.registry is None:
+    #    gen_profiles_solution.Log.e('Merging the profiles requires specifying --registry')
+    #    parser.print_help()
+    #    exit()
+
+    #registry = gen_profiles_solution.VulkanRegistry(args.registry)
+
+    #if (args.mode.lower() != 'union' and args.mode.lower() != 'intersection'):
+    #    gen_profiles_solution.Log.e('Mode must be either union or intersection')
+    #    parser.print_help()
+    #    exit()
+
+    #if args.strip_duplicate_structs:
+    #    gen_profiles_solution.Log.i('Stripping duplicated structures. `--strip-duplicate-structs` is set. Eg the output profiles file will contain VkPhysicalDeviceVulkan11Properties not VkPhysicalDeviceMultiviewPropertiesKHR.')
+    #    strip_duplicate_struct = True
+    #else:
+    #    strip_duplicate_struct = False
+
+    #if args.input_profiles is not None:
+    #    input_profile_names = args.input_profiles.split(',')
+    #else:
+    #    input_profile_names = list()
+
+    #profile_file = ProfileFile()
+
+    #if args.config is None:
+    #    profile_config = ProfileConfig(args.input, input_profile_names, args.profile_api_version, args.mode)
+
+    #    if args.profile_name is not None:
+    #        if not re.match('^VP_[A-Z0-9]+[A-Za-z0-9]+', args.profile_name):
+    #            gen_profiles_solution.Log.e('Invalid profile_name, must follow regex pattern ^VP_[A-Z0-9]+[A-Za-z0-9]+')
+    #            exit()
+    #        else:
+    #            profile_config.name = args.profile_name
+    #    elif args.output_profile is not None:
+    #        if not re.match('^VP_[A-Z0-9]+[A-Za-z0-9]+', args.output_profile):
+    #            gen_profiles_solution.Log.e('Invalid output_profile, must follow regex pattern ^VP_[A-Z0-9]+[A-Za-z0-9]+')
+    #            exit()
+    #        else:
+    #            profile_config.name = args.output_profile
+
+    #    if args.profile_version is not None:
+    #        profile_config.version = int(args.profile_version)
+
+    #    if args.profile_label is not None:
+    #        profile_config.label = args.profile_label
+
+    #    if args.profile_desc is not None:
+    #        profile_config.description = args.profile_desc
+
+    #    if args.profile_stage is not None:
+    #        profile_config.stage = args.profile_stage
+
+    #    if args.profile_date is not None:
+    #        profile_config.date = args.profile_date
+
+    #    if args.profile_required_profiles is not None:
+    #        profile_config.required_profiles = args.profile_required_profiles.split(',')
+
+    #    profile_configs.append(profile_config)
+
+    #else:
+    #    currentdir = os.path.dirname(args.config)
+        
+    #    json_file = open(args.config, "r")
+    #    json_data = json.load(json_file)
+
+    #    if json_data["$schema"]:
+    #        profile_file.set_schema(json_data["$schema"])
+    #    if json_data["contributors"]:
+    #        profile_file.set_contributors(json_data["contributors"])
+    #    if json_data["history"]:
+    #        profile_file.set_history(json_data["history"])
+
+    #    for profile_name in json_data["profiles"]:
+    #        profile_value = json_data["profiles"][profile_name]
+    #        profile_config = ProfileConfig(currentdir + "/" +  profile_value["input"], list(), profile_value["api-version"], args.mode)
+    #        profile_config.apply_json_value(profile_name, profile_value)
+    #        profile_configs.append(profile_config)
+
+    #for config in profile_configs:
+    #    profile_merger = ProfileMerger(registry)
+    #    profile_merger.merge(
+    #        config,
+    #        profile_file,
+    #        args.mode,
+    #        strip_duplicate_struct)
+
+    #profile_file.dump(args.output_path)
+
+if __name__ == '__main__':
+    print(sys.executable)
+    
+    sys.exit(main(sys.argv[1:]))
+

--- a/scripts/tests/test_json.py
+++ b/scripts/tests/test_json.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2026-2026 Google, Inc.
+# Copyright (C) 2026-2026 Valve Corporation
+# Copyright (c) 2026-2026 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: 
+# - Christophe Riccio <christophe@lunarg.com>
+
+import unittest
+
+from pathlib import Path
+
+from ..profiles import load_profiles_jsons
+
+class TestJsonMethods(unittest.TestCase):
+    def test_load_profiles_jsons(self):
+        repository_path = Path(__file__).resolve().parent.parent.parent
+        profiles_files_dir = repository_path / "profiles"
+       
+        jsons = load_profiles_jsons(profiles_files_dir)
+        
+        self.assertEqual(len(jsons), 8)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/scripts/tests/test_util.py
+++ b/scripts/tests/test_util.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2026-2026 Google, Inc.
+# Copyright (C) 2026-2026 Valve Corporation
+# Copyright (c) 2026-2026 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: 
+# - Christophe Riccio <christophe@lunarg.com>
+
+import unittest
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_upper(self):
+        self.assertEqual('foo'.upper(), 'FOO')
+
+    def test_isupper(self):
+        self.assertTrue('FOO'.isupper())
+        self.assertFalse('Foo'.isupper())
+
+    def test_split(self):
+        s = 'hello world'
+        self.assertEqual(s.split(), ['hello', 'world'])
+        # check that s.split fails when the separator is not a string
+        with self.assertRaises(TypeError):
+            s.split(2)
+
+if __name__ == '__main__':
+    unittest.main()
+
+


### PR DESCRIPTION
- Add python script to pull Vulkan capabilities dependencies using Vulkan-Object
- Add Python unit tests
- Add Github C.I. tests

```
profiles.py convert --input ./profiles/Android/ --output-path VP_ANDROID_vulkan_profile_2021_with_deps.json --output-profile VP_ANDROID_vulkan_profile_2021
```