### PR TITLE
profiles: Suggested clarification of profiles dependences

### DIFF
--- a/profiles/Android/VP_ANDROID_15_requirements.json
+++ b/profiles/Android/VP_ANDROID_15_requirements.json
@@ -5,7 +5,6 @@
             "extensions": {
                 "VK_KHR_maintenance5": 1,
                 "VK_KHR_shader_float16_int8": 1,
-                "VK_KHR_16bit_storage": 1,
                 "VK_KHR_vertex_attribute_divisor": 1,
                 "VK_EXT_custom_border_color": 1,
                 "VK_EXT_device_memory_report": 1,
@@ -15,11 +14,50 @@
                 "VK_EXT_primitive_topology_list_restart": 1,
                 "VK_EXT_provoking_vertex": 1,
                 "VK_EXT_scalar_block_layout": 1,
-                "VK_EXT_surface_maintenance1": 1,
-                "VK_EXT_swapchain_maintenance1": 1,
                 "VK_EXT_4444_formats": 1,
                 "VK_ANDROID_external_format_resolve": 1,
-                "VK_GOOGLE_surfaceless_query": 1
+                "VK_GOOGLE_surfaceless_query": 1,
+                "VK_KHR_dynamic_rendering": 1,
+                "VK_KHR_imageless_framebuffer": 1,
+                "VK_KHR_image_format_list": 1,
+                "VK_KHR_draw_indirect_count": 1,
+                "VK_KHR_shader_subgroup_extended_types": 1,
+                "VK_KHR_8bit_storage": 1,
+                "VK_KHR_shader_atomic_int64": 1,
+                "VK_KHR_shader_float_controls": 1,
+                "VK_KHR_depth_stencil_resolve": 1,
+                "VK_KHR_timeline_semaphore": 1,
+                "VK_KHR_vulkan_memory_model": 1,
+                "VK_KHR_shader_terminate_invocation": 1,
+                "VK_KHR_spirv_1_4": 1,
+                "VK_KHR_separate_depth_stencil_layouts": 1,
+                "VK_KHR_uniform_buffer_standard_layout": 1,
+                "VK_KHR_buffer_device_address": 1,
+                "VK_KHR_shader_integer_dot_product": 1,
+                "VK_KHR_shader_non_semantic_info": 1,
+                "VK_KHR_synchronization2": 1,
+                "VK_KHR_zero_initialize_workgroup_memory": 1,
+                "VK_KHR_copy_commands2": 1,
+                "VK_KHR_format_feature_flags2": 1,
+                "VK_KHR_maintenance4": 1,
+                "VK_EXT_texture_compression_astc_hdr": 1,
+                "VK_EXT_sampler_filter_minmax": 1,
+                "VK_EXT_inline_uniform_block": 1,
+                "VK_EXT_descriptor_indexing": 1,
+                "VK_EXT_shader_viewport_index_layer": 1,
+                "VK_EXT_pipeline_creation_feedback": 1,
+                "VK_EXT_subgroup_size_control": 1,
+                "VK_EXT_tooling_info": 1,
+                "VK_EXT_separate_stencil_usage": 1,
+                "VK_EXT_host_query_reset": 1,
+                "VK_EXT_extended_dynamic_state": 1,
+                "VK_EXT_shader_demote_to_helper_invocation": 1,
+                "VK_EXT_texel_buffer_alignment": 1,
+                "VK_EXT_private_data": 1,
+                "VK_EXT_pipeline_creation_cache_control": 1,
+                "VK_EXT_ycbcr_2plane_444_formats": 1,
+                "VK_EXT_image_robustness": 1,
+                "VK_EXT_extended_dynamic_state2": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
@@ -30,7 +68,29 @@
                     "shaderStorageImageWriteWithoutFormat": true,
                     "samplerAnisotropy": true
                 },
+                "VkPhysicalDeviceVulkan11Features": {
+                    "multiview": true,
+                    "samplerYcbcrConversion": true,
+                    "shaderDrawParameters": true,
+                    "variablePointers": true,
+                    "variablePointersStorageBuffer": true,
+                    "storageBuffer16BitAccess": true
+                },
                 "VkPhysicalDeviceVulkan12Features": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true,
+                    "shaderSubgroupExtendedTypes": true,
+                    "storageBuffer8BitAccess": true
+                },
+                "VkPhysicalDeviceShaderFloat16Int8Features": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true
+                },
+                "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true
+                },
+                "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                     "shaderFloat16": true,
                     "shaderInt8": true
                 },
@@ -49,42 +109,1127 @@
                 "VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR": {
                     "vertexAttributeInstanceRateDivisor": true
                 },
-                "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
-                    "samplerYcbcrConversion": true
-                },
-                "VkPhysicalDeviceShaderFloat16Int8Features": {
-                    "shaderFloat16": true,
-                    "shaderInt8": true
-                },
                 "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                    "shaderSubgroupExtendedTypes": true
+                },
+                "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                     "shaderSubgroupExtendedTypes": true
                 },
                 "VkPhysicalDevice8BitStorageFeatures": {
                     "storageBuffer8BitAccess": true
                 },
+                "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                    "storageBuffer8BitAccess": true
+                },
                 "VkPhysicalDevice16BitStorageFeatures": {
+                    "storageBuffer16BitAccess": true
+                },
+                "VkPhysicalDevice16BitStorageFeaturesKHR": {
                     "storageBuffer16BitAccess": true
                 }
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
+                        "maxPerStageDescriptorSamplers": 128,
                         "maxPerStageDescriptorUniformBuffers": 13,
                         "maxPerStageDescriptorStorageBuffers": 12,
-                        "maxColorAttachments": 8,
                         "maxPerStageDescriptorSampledImages": 128,
-                        "maxPerStageDescriptorSamplers": 128
+                        "maxColorAttachments": 8
                     }
                 },
                 "VkPhysicalDeviceVulkan11Properties": {
+                    "maxMultiviewInstanceIndex": 134217727,
+                    "maxMultiviewViewCount": 6,
                     "subgroupSupportedOperations": ["VK_SUBGROUP_FEATURE_BASIC_BIT", "VK_SUBGROUP_FEATURE_VOTE_BIT", "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT", "VK_SUBGROUP_FEATURE_BALLOT_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT"]
+                },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "supportedOperations": ["VK_SUBGROUP_FEATURE_BASIC_BIT", "VK_SUBGROUP_FEATURE_VOTE_BIT", "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT", "VK_SUBGROUP_FEATURE_BALLOT_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT"]
                 }
             },
             "formats": {
+                "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R16G16_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_D16_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_D32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
                 "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
                     }
                 },
@@ -93,17 +1238,39 @@
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
+                    },
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
                     }
                 }
             }
         },
         "primitivesGeneratedQuery": {
             "extensions": {
+                "VK_EXT_transform_feedback": 1,
                 "VK_EXT_primitives_generated_query": 1
             },
             "features": {
                 "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
                     "primitivesGeneratedQuery": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
                 }
             }
         },
@@ -111,6 +1278,17 @@
             "features": {
                 "VkPhysicalDeviceFeatures": {
                     "pipelineStatisticsQuery": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
                 }
             }
         },
@@ -122,6 +1300,17 @@
                 "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                     "bresenhamLines": true
                 }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
+                }
             }
         },
         "hwBresenhamLines": {
@@ -131,6 +1320,17 @@
             "features": {
                 "VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG": {
                     "relaxedLineRasterization": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
                 }
             }
         }

--- a/profiles/Android/VP_ANDROID_16_requirements.json
+++ b/profiles/Android/VP_ANDROID_16_requirements.json
@@ -3,7 +3,6 @@
     "capabilities": {
         "MUST": {
             "extensions": {
-                "VK_KHR_8bit_storage": 1,
                 "VK_KHR_load_store_op_none": 1,
                 "VK_KHR_maintenance6": 1,
                 "VK_KHR_map_memory2": 1,
@@ -20,18 +19,29 @@
                 "VK_EXT_transform_feedback": 1
             },
             "features": {
-                "VkPhysicalDeviceFeatures": {
-                    "fullDrawIndexUint32": true,
-                    "shaderInt16": true
+                "VkPhysicalDeviceVulkan11Features": {
+                    "protectedMemory": true
                 },
                 "VkPhysicalDeviceVulkan12Features": {
                     "samplerMirrorClampToEdge": true,
+                    "scalarBlockLayout": true
+                },
+                "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                    "scalarBlockLayout": true
+                },
+                "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
                     "scalarBlockLayout": true
                 },
                 "VkPhysicalDeviceProtectedMemoryFeatures": {
                     "protectedMemory": true
                 },
                 "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+                    "shaderIntegerDotProduct": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+                    "shaderIntegerDotProduct": true
+                },
+                "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
                     "shaderIntegerDotProduct": true
                 },
                 "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
@@ -47,47 +57,102 @@
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
-                        "bufferImageGranularity": 4096,
-                        "lineWidthGranularity": 0.5,
-                        "maxColorAttachments": 8,
-                        "maxComputeWorkGroupInvocations": 256,
-                        "maxComputeWorkGroupSize": [256, 256, 64],
-                        "maxImageArrayLayers": 2048,
                         "maxImageDimension1D": 8192,
                         "maxImageDimension2D": 8192,
                         "maxImageDimensionCube": 8192,
-                        "maxDescriptorSetStorageBuffers": 96,
-                        "maxDescriptorSetUniformBuffers": 90,
-                        "maxFragmentCombinedOutputResources": 16,
+                        "maxImageArrayLayers": 2048,
+                        "maxUniformBufferRange": 65536,
                         "maxPerStageDescriptorUniformBuffers": 15,
                         "maxPerStageResources": 200,
-                        "maxSamplerLodBias": 14,
-                        "maxUniformBufferRange": 65536,
+                        "maxDescriptorSetUniformBuffers": 90,
+                        "maxDescriptorSetStorageBuffers": 96,
                         "maxVertexOutputComponents": 72,
-                        "mipmapPrecisionBits": 6,
-                        "pointSizeGranularity": 0.125,
-                        "standardSampleLocations": true,
+                        "maxFragmentCombinedOutputResources": 16,
+                        "maxComputeWorkGroupInvocations": 256,
+                        "maxComputeWorkGroupSize": [256, 256, 64],
                         "subTexelPrecisionBits": 8,
+                        "mipmapPrecisionBits": 6,
+                        "maxSamplerLodBias": 14,
+                        "pointSizeGranularity": 0.125,
+                        "bufferImageGranularity": 4096,
+                        "lineWidthGranularity": 0.5,
                         "timestampComputeAndGraphics": true
                     }
+                },
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "subgroupSupportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
+                },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "supportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
                 },
                 "VkPhysicalDeviceFloatControlsProperties": {
                     "shaderSignedZeroInfNanPreserveFloat16": true,
                     "shaderSignedZeroInfNanPreserveFloat32": true
                 },
-                "VkPhysicalDeviceVulkan11Properties": {
-                    "subgroupSupportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true
+                },
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true
                 }
             }
         },
         "multisampledToSingleSampled": {
             "extensions": {
                 "VK_EXT_multisampled_render_to_single_sampled": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxImageDimension1D": 4096,
+                        "maxImageDimension2D": 4096,
+                        "maxImageDimensionCube": 4096,
+                        "maxImageArrayLayers": 256,
+                        "maxUniformBufferRange": 16384,
+                        "maxPerStageDescriptorUniformBuffers": 13,
+                        "maxPerStageResources": 44,
+                        "maxDescriptorSetUniformBuffers": 36,
+                        "maxDescriptorSetStorageBuffers": 24,
+                        "maxVertexOutputComponents": 64,
+                        "maxFragmentCombinedOutputResources": 8,
+                        "maxComputeWorkGroupInvocations": 128,
+                        "maxComputeWorkGroupSize": [128, 128, 64],
+                        "subTexelPrecisionBits": 4,
+                        "mipmapPrecisionBits": 4,
+                        "maxSamplerLodBias": 2.0,
+                        "pointSizeGranularity": 1
+                    }
+                }
             }
         },
         "shaderStencilExport": {
             "extensions": {
                 "VK_EXT_shader_stencil_export": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxImageDimension1D": 4096,
+                        "maxImageDimension2D": 4096,
+                        "maxImageDimensionCube": 4096,
+                        "maxImageArrayLayers": 256,
+                        "maxUniformBufferRange": 16384,
+                        "maxPerStageDescriptorUniformBuffers": 13,
+                        "maxPerStageResources": 44,
+                        "maxDescriptorSetUniformBuffers": 36,
+                        "maxDescriptorSetStorageBuffers": 24,
+                        "maxVertexOutputComponents": 64,
+                        "maxFragmentCombinedOutputResources": 8,
+                        "maxComputeWorkGroupInvocations": 128,
+                        "maxComputeWorkGroupSize": [128, 128, 64],
+                        "subTexelPrecisionBits": 4,
+                        "mipmapPrecisionBits": 4,
+                        "maxSamplerLodBias": 2.0,
+                        "pointSizeGranularity": 1
+                    }
+                }
             }
         }
     },

--- a/profiles/Android/VP_ANDROID_17_requirements.json
+++ b/profiles/Android/VP_ANDROID_17_requirements.json
@@ -10,90 +10,588 @@
                 "VK_KHR_pipeline_library": 1,
                 "VK_KHR_present_id2": 1,
                 "VK_KHR_present_wait2": 1,
-                "VK_KHR_shader_maximal_reconvergence": 1,
                 "VK_KHR_shader_quad_control": 1,
-                "VK_KHR_shader_subgroup_uniform_control_flow": 1,
-                "VK_KHR_swapchain_mutable_format": 1,
                 "VK_KHR_workgroup_memory_explicit_layout": 1,
                 "VK_EXT_calibrated_timestamps": 1,
-                "VK_EXT_custom_border_color": 1,
                 "VK_EXT_debug_utils": 1,
-                "VK_EXT_descriptor_indexing": 1,
                 "VK_EXT_device_address_binding_report": 1,
-                "VK_EXT_device_memory_report": 1,
-                "VK_EXT_external_memory_acquire_unmodified": 1,
                 "VK_EXT_graphics_pipeline_library": 1,
                 "VK_EXT_hdr_metadata": 1,
-                "VK_EXT_image_2d_view_of_3d": 1,
                 "VK_EXT_image_compression_control": 1,
                 "VK_EXT_image_compression_control_swapchain": 1,
                 "VK_EXT_present_mode_fifo_latest_ready": 1,
+                "VK_KHR_calibrated_timestamps": 1,
                 "VK_EXT_present_timing": 1,
-                "VK_EXT_primitive_topology_list_restart": 1,
-                "VK_EXT_provoking_vertex": 1,
-                "VK_EXT_surface_maintenance1": 1,
-                "VK_EXT_swapchain_maintenance1": 1,
-                "VK_EXT_transform_feedback": 1,
-                "VK_ANDROID_external_format_resolve": 1,
-                "VK_GOOGLE_surfaceless_query": 1
+                "VK_KHR_push_descriptor": 1,
+                "VK_KHR_global_priority": 1,
+                "VK_KHR_dynamic_rendering_local_read": 1,
+                "VK_KHR_index_type_uint8": 1,
+                "VK_KHR_line_rasterization": 1
             },
             "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "dualSrcBlend": true,
+                    "multiDrawIndirect": true,
+                    "shaderInt64": true
+                },
+                "VkPhysicalDeviceVulkan11Features": {
+                    "storageInputOutput16": true,
+                    "uniformAndStorageBuffer16BitAccess": true
+                },
                 "VkPhysicalDevice16BitStorageFeatures": {
                     "storageInputOutput16": true,
                     "uniformAndStorageBuffer16BitAccess": true
                 },
-                "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                    "customBorderColors": true
+                "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                    "storageInputOutput16": true,
+                    "uniformAndStorageBuffer16BitAccess": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "shaderBufferInt64Atomics": true
+                },
+                "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                    "descriptorBindingVariableDescriptorCount": true
                 },
                 "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                     "descriptorBindingVariableDescriptorCount": true
                 },
-                "VkPhysicalDeviceFeatures": {
-                    "dualSrcBlend": true,
-                    "multiDrawIndirect": true,
-                    "shaderInt64": true,
-                    "shaderStorageImageWriteWithoutFormat": true
+                "VkPhysicalDeviceVulkan14Features": {
+                    "indexTypeUint8": true,
+                    "vertexAttributeInstanceRateDivisor": true,
+                    "hostImageCopy": true
                 },
-                "VkPhysicalDeviceProtectedMemoryFeatures": {
-                    "protectedMemory": true
+                "VkPhysicalDeviceIndexTypeUint8Features": {
+                    "indexTypeUint8": true
+                },
+                "VkPhysicalDeviceIndexTypeUint8FeaturesKHR": {
+                    "indexTypeUint8": true
+                },
+                "VkPhysicalDeviceVertexAttributeDivisorFeatures": {
+                    "vertexAttributeInstanceRateDivisor": true
                 },
                 "VkPhysicalDeviceShaderAtomicInt64Features": {
                     "shaderBufferInt64Atomics": true
                 },
-                "VkPhysicalDeviceShaderFloat16Int8Features": {
-                    "shaderFloat16": true
+                "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                    "shaderBufferInt64Atomics": true
                 },
-                "VkPhysicalDeviceVulkan12Features": {
-                    "descriptorBindingVariableDescriptorCount": true,
-                    "shaderFloat16": true
+                "VkPhysicalDeviceHostImageCopyFeatures": {
+                    "hostImageCopy": true
                 },
-                "VkPhysicalDeviceVulkan14Features": {
+                "VkPhysicalDeviceHostImageCopyFeaturesEXT": {
                     "hostImageCopy": true
                 }
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
-                        "maxDescriptorSetStorageImages": 144
+                        "maxImageDimension3D": 512,
+                        "maxPerStageDescriptorStorageImages": 4,
+                        "maxPerStageDescriptorInputAttachments": 4,
+                        "maxDescriptorSetSamplers": 48,
+                        "maxDescriptorSetStorageBuffersDynamic": 4,
+                        "maxDescriptorSetSampledImages": 48,
+                        "maxDescriptorSetStorageImages": 144,
+                        "maxDescriptorSetInputAttachments": 4,
+                        "maxFragmentInputComponents": 64,
+                        "maxFragmentOutputAttachments": 4,
+                        "viewportBoundsRange": [-8192, 8191],
+                        "sampledImageIntegerSampleCounts": ["VK_SAMPLE_COUNT_1_BIT"]
                     }
-                },
-                "VkPhysicalDeviceVulkan11Properties": {
-                    "subgroupSupportedStages": ["VK_SHADER_STAGE_FRAGMENT_BIT"]
                 }
             },
             "formats": {
-                "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SRGB": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_SRGB": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UINT": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
                     }
                 },
-                "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                "VK_FORMAT_R16G16_SINT": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_D32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"]
+                    }
+                },
+                "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_S8_UINT": {
+                    "VkFormatProperties3": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
                     }
                 }
             }
@@ -106,6 +604,13 @@
                 "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
                     "primitivesGeneratedQuery": true
                 }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 12
+                    }
+                }
             }
         },
         "pipelineStatisticsQuery": {
@@ -113,16 +618,37 @@
                 "VkPhysicalDeviceFeatures": {
                     "pipelineStatisticsQuery": true
                 }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 12
+                    }
+                }
             }
         },
         "multisampledToSingleSampled": {
             "extensions": {
                 "VK_EXT_multisampled_render_to_single_sampled": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 12
+                    }
+                }
             }
         },
         "shaderStencilExport": {
             "extensions": {
                 "VK_EXT_shader_stencil_export": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 12
+                    }
+                }
             }
         }
     },
@@ -185,7 +711,7 @@
                 ["primitivesGeneratedQuery", "pipelineStatisticsQuery"],
                 ["multisampledToSingleSampled", "shaderStencilExport"]
             ],
-            "profiles": ["VP_ANDROID_vulkan_profile_2025"]
+            "profiles": ["VP_ANDROID_vulkan_profile_2025", "VP_ANDROID_16_requirements"]
         }
     }
 }

--- a/profiles/Android/VP_ANDROID_vulkan_profile_2021.json
+++ b/profiles/Android/VP_ANDROID_vulkan_profile_2021.json
@@ -24,7 +24,9 @@
                 "VK_KHR_external_semaphore_fd": 1,
                 "VK_KHR_external_fence": 1,
                 "VK_KHR_external_fence_fd": 1,
-                "VK_KHR_variable_pointers": 1
+                "VK_KHR_variable_pointers": 1,
+                "VK_EXT_surface_maintenance1": 1,
+                "VK_EXT_swapchain_maintenance1": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {

--- a/profiles/Android/VP_ANDROID_vulkan_profile_2022.json
+++ b/profiles/Android/VP_ANDROID_vulkan_profile_2022.json
@@ -3,48 +3,24 @@
     "capabilities": {
         "baseline": {
             "extensions": {
-                "VK_KHR_surface": 1,
-                "VK_KHR_android_surface": 1,
-                "VK_KHR_swapchain": 1,
-                "VK_KHR_get_physical_device_properties2": 1,
-                "VK_KHR_maintenance1": 1,
-                "VK_EXT_swapchain_colorspace": 1,
-                "VK_KHR_get_surface_capabilities2": 1,
-                "VK_KHR_incremental_present": 1,
-                "VK_GOOGLE_display_timing": 1,
-                "VK_KHR_descriptor_update_template": 1,
-                "VK_KHR_get_memory_requirements2": 1,
-                "VK_KHR_dedicated_allocation": 1,
-                "VK_KHR_storage_buffer_storage_class": 1,
-                "VK_KHR_external_semaphore_capabilities": 1,
-                "VK_KHR_external_semaphore": 1,
-                "VK_KHR_external_memory_capabilities": 1,
-                "VK_KHR_external_memory": 1,
-                "VK_KHR_external_fence_capabilities": 1,
-                "VK_KHR_external_semaphore_fd": 1,
-                "VK_KHR_external_fence": 1,
-                "VK_KHR_external_fence_fd": 1,
-                "VK_KHR_variable_pointers": 1,
-                "VK_ANDROID_external_memory_android_hardware_buffer": 1,
                 "VK_EXT_queue_family_foreign": 1,
+                "VK_ANDROID_external_memory_android_hardware_buffer": 1,
                 "VK_KHR_driver_properties": 1,
                 "VK_KHR_create_renderpass2": 1,
-                "VK_KHR_sampler_mirror_clamp_to_edge": 1
+                "VK_KHR_sampler_mirror_clamp_to_edge": 1,
+                "VK_KHR_multiview": 1,
+                "VK_KHR_device_group_creation": 1,
+                "VK_KHR_device_group": 1,
+                "VK_KHR_shader_draw_parameters": 1,
+                "VK_KHR_16bit_storage": 1,
+                "VK_KHR_maintenance2": 1,
+                "VK_KHR_relaxed_block_layout": 1,
+                "VK_KHR_sampler_ycbcr_conversion": 1,
+                "VK_KHR_bind_memory2": 1,
+                "VK_KHR_maintenance3": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
-                    "depthBiasClamp": true,
-                    "fragmentStoresAndAtomics": true,
-                    "fullDrawIndexUint32": true,
-                    "imageCubeArray": true,
-                    "independentBlend": true,
-                    "robustBufferAccess": true,
-                    "sampleRateShading": true,
-                    "shaderSampledImageArrayDynamicIndexing": true,
-                    "shaderStorageImageArrayDynamicIndexing": true,
-                    "shaderUniformBufferArrayDynamicIndexing": true,
-                    "textureCompressionASTC_LDR": true,
-                    "textureCompressionETC2": true,
                     "shaderInt16": true,
                     "shaderStorageBufferArrayDynamicIndexing": true,
                     "largePoints": true
@@ -52,13 +28,34 @@
                 "VkPhysicalDeviceMultiviewFeatures": {
                     "multiview": true
                 },
+                "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                    "multiview": true
+                },
                 "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                    "samplerYcbcrConversion": true
+                },
+                "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
                     "samplerYcbcrConversion": true
                 },
                 "VkPhysicalDeviceShaderDrawParametersFeatures": {
                     "shaderDrawParameters": true
                 },
+                "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                    "shaderDrawParameters": true
+                },
                 "VkPhysicalDeviceVariablePointersFeatures": {
+                    "variablePointers": true,
+                    "variablePointersStorageBuffer": true
+                },
+                "VkPhysicalDeviceVariablePointerFeatures": {
+                    "variablePointers": true,
+                    "variablePointersStorageBuffer": true
+                },
+                "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                    "variablePointers": true,
+                    "variablePointersStorageBuffer": true
+                },
+                "VkPhysicalDeviceVariablePointersFeaturesKHR": {
                     "variablePointers": true,
                     "variablePointersStorageBuffer": true
                 }
@@ -66,711 +63,16 @@
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
-                        "maxImageDimension1D": 4096,
-                        "maxImageDimension2D": 4096,
-                        "maxImageDimension3D": 512,
-                        "maxImageDimensionCube": 4096,
-                        "maxImageArrayLayers": 256,
-                        "maxTexelBufferElements": 65536,
-                        "maxUniformBufferRange": 16384,
-                        "maxStorageBufferRange": 134217728,
-                        "maxPushConstantsSize": 128,
-                        "maxMemoryAllocationCount": 4096,
-                        "maxSamplerAllocationCount": 4000,
-                        "maxBoundDescriptorSets": 4,
-                        "maxPerStageDescriptorSamplers": 16,
-                        "maxPerStageDescriptorUniformBuffers": 12,
-                        "maxPerStageDescriptorStorageBuffers": 4,
-                        "maxPerStageDescriptorSampledImages": 16,
-                        "maxPerStageDescriptorStorageImages": 4,
-                        "maxPerStageDescriptorInputAttachments": 4,
-                        "maxPerStageResources": 44,
-                        "maxDescriptorSetSamplers": 48,
-                        "maxDescriptorSetUniformBuffers": 36,
-                        "maxDescriptorSetUniformBuffersDynamic": 8,
-                        "maxDescriptorSetStorageBuffers": 24,
-                        "maxDescriptorSetStorageBuffersDynamic": 4,
-                        "maxDescriptorSetSampledImages": 48,
-                        "maxDescriptorSetStorageImages": 12,
-                        "maxDescriptorSetInputAttachments": 4,
-                        "maxVertexInputAttributes": 16,
-                        "maxVertexInputBindings": 16,
-                        "maxVertexInputAttributeOffset": 2047,
-                        "maxVertexInputBindingStride": 2048,
-                        "maxVertexOutputComponents": 64,
-                        "maxFragmentInputComponents": 64,
-                        "maxFragmentOutputAttachments": 4,
-                        "maxFragmentCombinedOutputResources": 8,
-                        "maxComputeSharedMemorySize": 16384,
-                        "maxComputeWorkGroupCount": [65535, 65535, 65535],
-                        "maxComputeWorkGroupInvocations": 128,
-                        "maxComputeWorkGroupSize": [128, 128, 64],
-                        "subPixelPrecisionBits": 4,
-                        "subTexelPrecisionBits": 4,
-                        "mipmapPrecisionBits": 4,
-                        "maxDrawIndexedIndexValue": 4294967295,
-                        "maxDrawIndirectCount": 1,
-                        "maxSamplerLodBias": 2.0,
-                        "maxSamplerAnisotropy": 1.0,
-                        "maxViewports": 1,
-                        "maxViewportDimensions": [4096, 4096],
-                        "viewportBoundsRange": [-8192, 8191],
-                        "minTexelBufferOffsetAlignment": 256,
-                        "minUniformBufferOffsetAlignment": 256,
-                        "minStorageBufferOffsetAlignment": 256,
-                        "minTexelOffset": -8,
-                        "maxTexelOffset": 7,
-                        "minInterpolationOffset": -0.5,
-                        "maxInterpolationOffset": 0.4375,
-                        "subPixelInterpolationOffsetBits": 4,
-                        "maxFramebufferWidth": 4096,
-                        "maxFramebufferHeight": 4096,
-                        "maxFramebufferLayers": 256,
-                        "framebufferColorSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "framebufferDepthSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "framebufferStencilSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "framebufferNoAttachmentsSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "maxColorAttachments": 4,
-                        "sampledImageColorSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "sampledImageIntegerSampleCounts": ["VK_SAMPLE_COUNT_1_BIT"],
-                        "sampledImageDepthSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "sampledImageStencilSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "storageImageSampleCounts": ["VK_SAMPLE_COUNT_1_BIT"],
-                        "maxSampleMaskWords": 1,
-                        "discreteQueuePriorities": 2,
-                        "pointSizeGranularity": 1,
-                        "pointSizeRange": [1.0, 511],
-                        "standardSampleLocations": true
+                        "pointSizeRange": [1.0, 511]
                     }
                 },
                 "VkPhysicalDeviceMultiviewProperties": {
                     "maxMultiviewInstanceIndex": 134217727,
                     "maxMultiviewViewCount": 6
-                }
-            },
-            "formats": {
-                "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
                 },
-                "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_R8_UNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_SNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8_UNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8_SNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_UNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SRGB": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_B8G8R8A8_UNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_B8G8R8A8_SRGB": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_UNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": [],
-                        "optimalTilingFeatures": [],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_SNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": [],
-                        "optimalTilingFeatures": [],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16_SNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": [],
-                        "optimalTilingFeatures": [],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_R16G16_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": [],
-                        "optimalTilingFeatures": [],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_UINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_SINT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"]
-                    }
-                },
-                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_D16_UNORM": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": [],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_D32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": [],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
-                },
-                "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
-                        "bufferFeatures": []
-                    }
+                "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                    "maxMultiviewInstanceIndex": 134217727,
+                    "maxMultiviewViewCount": 6
                 }
             }
         }
@@ -813,7 +115,8 @@
                     "comment": "Renamed/rebranded from 'VP_ANDROID_baseline_2022' (a.k.a. Android Baseline Profile 2022 or ABP 2022) to 'VP_ANDROID_vulkan_profile_2022' (a.k.a. Android Vulkan Profile 2022 or AVP 2022)"
                 }
             ],
-            "capabilities": ["baseline"]
+            "capabilities": ["baseline"],
+            "profiles": ["VP_ANDROID_vulkan_profile_2021"]
         }
     }
 }

--- a/profiles/Android/VP_ANDROID_vulkan_profile_2025.json
+++ b/profiles/Android/VP_ANDROID_vulkan_profile_2025.json
@@ -3,196 +3,345 @@
     "capabilities": {
         "baseline": {
             "extensions": {
-                "VK_KHR_android_surface": 1,
-                "VK_KHR_bind_memory2": 1,
-                "VK_KHR_create_renderpass2": 1,
-                "VK_KHR_dedicated_allocation": 1,
-                "VK_KHR_descriptor_update_template": 1,
-                "VK_KHR_device_group": 1,
-                "VK_KHR_device_group_creation": 1,
-                "VK_KHR_driver_properties": 1,
-                "VK_KHR_external_fence": 1,
-                "VK_KHR_external_fence_capabilities": 1,
-                "VK_KHR_external_fence_fd": 1,
-                "VK_KHR_external_memory": 1,
-                "VK_KHR_external_memory_capabilities": 1,
                 "VK_KHR_external_memory_fd": 1,
-                "VK_KHR_external_semaphore": 1,
-                "VK_KHR_external_semaphore_capabilities": 1,
-                "VK_KHR_external_semaphore_fd": 1,
-                "VK_KHR_get_memory_requirements2": 1,
-                "VK_KHR_get_physical_device_properties2": 1,
-                "VK_KHR_get_surface_capabilities2": 1,
                 "VK_KHR_image_format_list": 1,
-                "VK_KHR_incremental_present": 1,
-                "VK_KHR_maintenance1": 1,
-                "VK_KHR_maintenance2": 1,
-                "VK_KHR_maintenance3": 1,
-                "VK_KHR_multiview": 1,
-                "VK_KHR_relaxed_block_layout": 1,
-                "VK_KHR_sampler_mirror_clamp_to_edge": 1,
-                "VK_KHR_sampler_ycbcr_conversion": 1,
-                "VK_KHR_shader_draw_parameters": 1,
                 "VK_KHR_shader_float16_int8": 1,
                 "VK_KHR_shader_float_controls": 1,
-                "VK_KHR_storage_buffer_storage_class": 1,
-                "VK_KHR_surface": 1,
-                "VK_KHR_swapchain": 1,
-                "VK_KHR_variable_pointers": 1,
                 "VK_KHR_vulkan_memory_model": 1,
-                "VK_ANDROID_external_memory_android_hardware_buffer": 1,
-                "VK_GOOGLE_display_timing": 1,
                 "VK_EXT_debug_report": 1,
                 "VK_EXT_host_query_reset": 1,
                 "VK_EXT_index_type_uint8": 1,
-                "VK_EXT_queue_family_foreign": 1,
                 "VK_EXT_scalar_block_layout": 1,
-                "VK_EXT_separate_stencil_usage": 1,
-                "VK_EXT_swapchain_colorspace": 1
+                "VK_EXT_separate_stencil_usage": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
-                    "depthBiasClamp": true,
                     "drawIndirectFirstInstance": true,
-                    "fragmentStoresAndAtomics": true,
-                    "fullDrawIndexUint32": true,
-                    "imageCubeArray": true,
-                    "independentBlend": true,
-                    "largePoints": true,
                     "occlusionQueryPrecise": true,
-                    "robustBufferAccess": true,
-                    "sampleRateShading": true,
-                    "shaderInt16": true,
-                    "shaderSampledImageArrayDynamicIndexing": true,
-                    "shaderStorageBufferArrayDynamicIndexing": true,
-                    "shaderStorageImageArrayDynamicIndexing": true,
                     "shaderStorageImageExtendedFormats": true,
-                    "shaderStorageImageReadWithoutFormat": true,
-                    "shaderUniformBufferArrayDynamicIndexing": true,
-                    "textureCompressionASTC_LDR": true,
-                    "textureCompressionETC2": true
-                },
-                "VkPhysicalDeviceMultiviewFeatures": {
-                    "multiview": true
-                },
-                "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
-                    "samplerYcbcrConversion": true
-                },
-                "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                    "shaderDrawParameters": true
-                },
-                "VkPhysicalDeviceVariablePointerFeatures": {
-                    "variablePointers": true,
-                    "variablePointersStorageBuffer": true
-                },
-                "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                    "variablePointers": true,
-                    "variablePointersStorageBuffer": true
+                    "shaderStorageImageReadWithoutFormat": true
                 }
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
-                        "bufferImageGranularity": 4096,
-                        "discreteQueuePriorities": 2,
-                        "framebufferColorSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "framebufferDepthSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "framebufferStencilSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "framebufferNoAttachmentsSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "maxBoundDescriptorSets": 4,
-                        "maxColorAttachments": 8,
-                        "maxComputeSharedMemorySize": 16384,
-                        "maxComputeWorkGroupCount": [65535, 65535, 65535],
-                        "maxComputeWorkGroupInvocations": 256,
-                        "maxComputeWorkGroupSize": [256, 256, 64],
-                        "maxDescriptorSetInputAttachments": 8,
-                        "maxDescriptorSetSampledImages": 256,
+                        "maxImageDimension3D": 2048,
+                        "maxUniformBufferRange": 65536,
+                        "maxPerStageDescriptorSamplers": 32,
+                        "maxPerStageDescriptorUniformBuffers": 36,
+                        "maxPerStageDescriptorStorageBuffers": 35,
+                        "maxPerStageDescriptorSampledImages": 48,
+                        "maxPerStageDescriptorStorageImages": 8,
+                        "maxPerStageDescriptorInputAttachments": 8,
+                        "maxPerStageResources": 224,
                         "maxDescriptorSetSamplers": 256,
+                        "maxDescriptorSetUniformBuffers": 216,
                         "maxDescriptorSetStorageBuffers": 210,
                         "maxDescriptorSetStorageBuffersDynamic": 8,
+                        "maxDescriptorSetSampledImages": 256,
                         "maxDescriptorSetStorageImages": 126,
-                        "maxDescriptorSetUniformBuffers": 216,
-                        "maxDescriptorSetUniformBuffersDynamic": 8,
-                        "maxDrawIndexedIndexValue": 4294967295,
-                        "maxFramebufferHeight": 4096,
-                        "maxFramebufferLayers": 256,
-                        "maxFramebufferWidth": 4096,
-                        "maxFragmentCombinedOutputResources": 8,
+                        "maxDescriptorSetInputAttachments": 8,
+                        "maxVertexOutputComponents": 128,
                         "maxFragmentInputComponents": 112,
                         "maxFragmentOutputAttachments": 8,
-                        "maxImageArrayLayers": 256,
-                        "maxImageDimension1D": 4096,
-                        "maxImageDimension2D": 4096,
-                        "maxImageDimension3D": 2048,
-                        "maxImageDimensionCube": 4096,
-                        "maxInterpolationOffset": 0.4375,
-                        "maxMemoryAllocationCount": 4096,
-                        "maxPerStageDescriptorInputAttachments": 8,
-                        "maxPerStageDescriptorSampledImages": 48,
-                        "maxPerStageDescriptorSamplers": 32,
-                        "maxPerStageDescriptorStorageBuffers": 35,
-                        "maxPerStageDescriptorStorageImages": 8,
-                        "maxPerStageDescriptorUniformBuffers": 36,
-                        "maxPerStageResources": 224,
-                        "maxPushConstantsSize": 128,
-                        "maxSamplerAllocationCount": 4000,
+                        "maxComputeWorkGroupInvocations": 256,
+                        "maxComputeWorkGroupSize": [256, 256, 64],
+                        "subTexelPrecisionBits": 8,
                         "maxSamplerLodBias": 15.0,
-                        "maxStorageBufferRange": 134217728,
-                        "maxTexelBufferElements": 65536,
-                        "maxTexelOffset": 7,
-                        "maxUniformBufferRange": 65536,
-                        "maxVertexInputAttributeOffset": 2047,
-                        "maxVertexInputAttributes": 16,
-                        "maxVertexInputBindingStride": 2048,
-                        "maxVertexInputBindings": 16,
-                        "maxVertexOutputComponents": 128,
-                        "maxViewportDimensions": [4096, 4096],
-                        "minInterpolationOffset": -0.5,
-                        "minStorageBufferOffsetAlignment": 256,
-                        "minTexelBufferOffsetAlignment": 256,
-                        "minTexelOffset": -8,
-                        "minUniformBufferOffsetAlignment": 256,
-                        "mipmapPrecisionBits": 4,
+                        "viewportBoundsRange": [-8192, 8192],
+                        "maxColorAttachments": 8,
+                        "sampledImageIntegerSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
+                        "pointSizeGranularity": 0.125,
+                        "bufferImageGranularity": 4096,
                         "nonCoherentAtomSize": 64,
                         "optimalBufferCopyRowPitchAlignment": 64,
-                        "optimalBufferCopyOffsetAlignment": 64,
-                        "pointSizeGranularity": 0.125,
-                        "sampledImageColorSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "sampledImageIntegerSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "sampledImageDepthSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "sampledImageStencilSampleCounts": ["VK_SAMPLE_COUNT_1_BIT", "VK_SAMPLE_COUNT_4_BIT"],
-                        "storageImageSampleCounts": ["VK_SAMPLE_COUNT_1_BIT"],
-                        "standardSampleLocations": true,
-                        "subPixelInterpolationOffsetBits": 4,
-                        "subPixelPrecisionBits": 4,
-                        "subTexelPrecisionBits": 8,
-                        "viewportBoundsRange": [-8192, 8192]
+                        "optimalBufferCopyOffsetAlignment": 64
                     }
-                },
-                "VkPhysicalDeviceMultiviewProperties": {
-                    "maxMultiviewViewCount": 6,
-                    "maxMultiviewInstanceIndex": 134217727
                 }
             },
             "formats": {
+                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
                 "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SRGB": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_SRGB": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
-                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
                     "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
                 "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
                     "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SNORM": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_UINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SINT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                    "VkFormatProperties": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_D32_SFLOAT": {
+                    "VkFormatProperties": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
                 "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
@@ -209,221 +358,6 @@
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
-                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
                 "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
@@ -436,95 +370,6 @@
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT"]
                     }
                 },
-                "VK_FORMAT_B8G8R8A8_SRGB": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_B8G8R8A8_UNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_D16_UNORM": {
-                    "VkFormatProperties": {
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_D32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
                 "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
@@ -535,34 +380,6 @@
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SFLOAT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_SNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16B16A16_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
                 "VK_FORMAT_R16G16B16A16_UNORM": {
@@ -582,95 +399,11 @@
                         "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
                     }
                 },
-                "VK_FORMAT_R16G16_SFLOAT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16_SNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16G16_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
                 "VK_FORMAT_R16G16_UNORM": {
                     "VkFormatProperties": {
                         "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_SFLOAT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_SNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R16_UNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32B32A32_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
                 "VK_FORMAT_R32G32B32_SFLOAT": {
@@ -688,48 +421,6 @@
                         "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
                     }
                 },
-                "VK_FORMAT_R32G32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32G32_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32_SFLOAT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R32_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
                 "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
@@ -740,46 +431,6 @@
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_SRGB": {
-                    "VkFormatProperties": {
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8B8A8_UNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
                 "VK_FORMAT_R8G8B8_SINT": {
@@ -802,72 +453,16 @@
                         "bufferFeatures": ["VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"]
                     }
                 },
-                "VK_FORMAT_R8G8_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8_SNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
                 "VK_FORMAT_R8G8_SRGB": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT"]
                     }
                 },
-                "VK_FORMAT_R8G8_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8G8_UNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_SINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_SNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
                 "VK_FORMAT_R8_SRGB": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_UINT": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
-                    }
-                },
-                "VK_FORMAT_R8_UNORM": {
-                    "VkFormatProperties": {
-                        "bufferFeatures": ["VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"],
-                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"],
-                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"]
                     }
                 },
                 "VK_FORMAT_S8_UINT": {
@@ -910,7 +505,8 @@
                     "comment": "Updated the profile based on partner feedbacks"
                 }
             ],
-            "capabilities": ["baseline"]
+            "capabilities": ["baseline"],
+            "profiles": ["VP_ANDROID_vulkan_profile_2022"]
         }
     }
 }


### PR DESCRIPTION
Generated using the command:

```
vkprofiles convert 
      --registry E:\\Github\\khronos\\Vulkan-Profiles\\external\\Debug\\64\\Vulkan-Headers\\registry\\vk.xml
      --input E:\\Github\\khronos\\Vulkan-Profiles\\profiles\\Android
      --output E:\\Github\\khronos\\Vulkan-Profiles\\build\\profiles
      --mode strip-duplication pull-dependences pull-aliases pull-promoted-extensions ignore-extension-versions
```

A suggestion:
- Android profiles have profiles dependencies in black:
<img width="1539" height="1068" alt="image" src="https://github.com/user-attachments/assets/50581638-b94d-42ec-8c0f-564cb6ef5371" />
I think it would make sense to consider adding the dependencies in red. 

This simplifies a lot the Android profiles, it identifies what new capabilities was added to each profile.


