### PR TITLE
Android: Pulled Vulkan capabilities dependences

### DIFF
--- a/profiles/Android/VP_ANDROID_15_requirements.json
+++ b/profiles/Android/VP_ANDROID_15_requirements.json
@@ -5,7 +5,6 @@
             "extensions": {
                 "VK_KHR_maintenance5": 1,
                 "VK_KHR_shader_float16_int8": 1,
-                "VK_KHR_16bit_storage": 1,
                 "VK_KHR_vertex_attribute_divisor": 1,
                 "VK_EXT_custom_border_color": 1,
                 "VK_EXT_device_memory_report": 1,
@@ -30,9 +29,20 @@
                     "shaderStorageImageWriteWithoutFormat": true,
                     "samplerAnisotropy": true
                 },
+                "VkPhysicalDeviceVulkan11Features": {
+                    "multiview": true,
+                    "samplerYcbcrConversion": true,
+                    "shaderDrawParameters": true,
+                    "variablePointers": true,
+                    "variablePointersStorageBuffer": true,
+                    "storageBuffer16BitAccess": true
+                },
                 "VkPhysicalDeviceVulkan12Features": {
                     "shaderFloat16": true,
-                    "shaderInt8": true
+                    "shaderInt8": true,
+                    "shaderSubgroupExtendedTypes": true,
+                    "storageBuffer8BitAccess": true,
+                    "scalarBlockLayout": true
                 },
                 "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
                     "customBorderColors": true
@@ -46,45 +56,1133 @@
                 "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                     "indexTypeUint8": true
                 },
+                "VkPhysicalDeviceIndexTypeUint8FeaturesKHR": {
+                    "indexTypeUint8": true
+                },
                 "VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR": {
                     "vertexAttributeInstanceRateDivisor": true
                 },
-                "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
-                    "samplerYcbcrConversion": true
+                "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                    "vertexAttributeInstanceRateDivisor": true
                 },
-                "VkPhysicalDeviceShaderFloat16Int8Features": {
-                    "shaderFloat16": true,
-                    "shaderInt8": true
+                "VkPhysicalDeviceMaintenance5FeaturesKHR": {
+                    "maintenance5": true
                 },
-                "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
-                    "shaderSubgroupExtendedTypes": true
+                "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                    "deviceMemoryReport": true
                 },
-                "VkPhysicalDevice8BitStorageFeatures": {
-                    "storageBuffer8BitAccess": true
+                "VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR": {
+                    "swapchainMaintenance1": true
                 },
-                "VkPhysicalDevice16BitStorageFeatures": {
-                    "storageBuffer16BitAccess": true
+                "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                    "formatA4R4G4B4": true
+                },
+                "VkPhysicalDeviceExternalFormatResolveFeaturesANDROID": {
+                    "externalFormatResolve": true
                 }
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
+                        "maxPerStageDescriptorSamplers": 128,
                         "maxPerStageDescriptorUniformBuffers": 13,
                         "maxPerStageDescriptorStorageBuffers": 12,
-                        "maxColorAttachments": 8,
                         "maxPerStageDescriptorSampledImages": 128,
-                        "maxPerStageDescriptorSamplers": 128
+                        "maxColorAttachments": 8
                     }
                 },
                 "VkPhysicalDeviceVulkan11Properties": {
+                    "maxMultiviewInstanceIndex": 134217727,
+                    "maxMultiviewViewCount": 6,
                     "subgroupSupportedOperations": ["VK_SUBGROUP_FEATURE_BASIC_BIT", "VK_SUBGROUP_FEATURE_VOTE_BIT", "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT", "VK_SUBGROUP_FEATURE_BALLOT_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT"]
+                },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "supportedOperations": ["VK_SUBGROUP_FEATURE_BASIC_BIT", "VK_SUBGROUP_FEATURE_VOTE_BIT", "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT", "VK_SUBGROUP_FEATURE_BALLOT_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_BIT", "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT"]
                 }
             },
             "formats": {
+                "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R16G16_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_UINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SINT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_D16_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_D32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
+                "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    }
+                },
                 "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
                     }
                 },
@@ -93,17 +1191,34 @@
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
+                    },
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
                     }
                 }
             }
         },
         "primitivesGeneratedQuery": {
             "extensions": {
+                "VK_EXT_transform_feedback": 1,
                 "VK_EXT_primitives_generated_query": 1
             },
-            "features": {
-                "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                    "primitivesGeneratedQuery": true
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
                 }
             }
         },
@@ -112,15 +1227,32 @@
                 "VkPhysicalDeviceFeatures": {
                     "pipelineStatisticsQuery": true
                 }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
+                }
             }
         },
         "swBresenhamLines": {
             "extensions": {
                 "VK_EXT_line_rasterization": 1
             },
-            "features": {
-                "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
-                    "bresenhamLines": true
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
                 }
             }
         },
@@ -128,9 +1260,143 @@
             "extensions": {
                 "VK_IMG_relaxed_line_rasterization": 1
             },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
+                }
+            }
+        },
+        "vulkan11pulledrequirements": {
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxPerStageDescriptorSamplers": 16,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageDescriptorStorageBuffers": 4,
+                        "maxPerStageDescriptorSampledImages": 16,
+                        "maxColorAttachments": 4
+                    }
+                }
+            }
+        },
+        "vulkan12pulledrequirements": {
+            "extensions": {
+                "VK_KHR_imageless_framebuffer": 1,
+                "VK_KHR_image_format_list": 1,
+                "VK_KHR_draw_indirect_count": 1,
+                "VK_KHR_shader_subgroup_extended_types": 1,
+                "VK_KHR_8bit_storage": 1,
+                "VK_KHR_shader_atomic_int64": 1,
+                "VK_KHR_shader_float_controls": 1,
+                "VK_KHR_depth_stencil_resolve": 1,
+                "VK_KHR_timeline_semaphore": 1,
+                "VK_KHR_vulkan_memory_model": 1,
+                "VK_KHR_spirv_1_4": 1,
+                "VK_KHR_separate_depth_stencil_layouts": 1,
+                "VK_KHR_uniform_buffer_standard_layout": 1,
+                "VK_KHR_buffer_device_address": 1,
+                "VK_EXT_sampler_filter_minmax": 1,
+                "VK_EXT_descriptor_indexing": 1,
+                "VK_EXT_shader_viewport_index_layer": 1,
+                "VK_EXT_separate_stencil_usage": 1,
+                "VK_EXT_host_query_reset": 1
+            },
             "features": {
-                "VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG": {
-                    "relaxedLineRasterization": true
+                "VkPhysicalDeviceVulkan12Features": {
+                    "imagelessFramebuffer": true,
+                    "shaderBufferInt64Atomics": true,
+                    "timelineSemaphore": true,
+                    "vulkanMemoryModel": true,
+                    "separateDepthStencilLayouts": true,
+                    "uniformBufferStandardLayout": true,
+                    "bufferDeviceAddress": true,
+                    "shaderUniformTexelBufferArrayDynamicIndexing": true,
+                    "shaderStorageTexelBufferArrayDynamicIndexing": true,
+                    "shaderSampledImageArrayNonUniformIndexing": true,
+                    "shaderStorageBufferArrayNonUniformIndexing": true,
+                    "shaderUniformTexelBufferArrayNonUniformIndexing": true,
+                    "descriptorBindingSampledImageUpdateAfterBind": true,
+                    "descriptorBindingStorageImageUpdateAfterBind": true,
+                    "descriptorBindingStorageBufferUpdateAfterBind": true,
+                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "runtimeDescriptorArray": true,
+                    "hostQueryReset": true,
+                    "subgroupBroadcastDynamicId": true,
+                    "samplerMirrorClampToEdge": true,
+                    "drawIndirectCount": true,
+                    "descriptorIndexing": true,
+                    "shaderOutputViewportIndex": true,
+                    "shaderOutputLayer": true,
+                    "samplerFilterMinmax": true
+                }
+            }
+        },
+        "vulkan13pulledrequirements": {
+            "extensions": {
+                "VK_KHR_dynamic_rendering": 1,
+                "VK_KHR_shader_terminate_invocation": 1,
+                "VK_KHR_shader_integer_dot_product": 1,
+                "VK_KHR_shader_non_semantic_info": 1,
+                "VK_KHR_synchronization2": 1,
+                "VK_KHR_zero_initialize_workgroup_memory": 1,
+                "VK_KHR_copy_commands2": 1,
+                "VK_KHR_format_feature_flags2": 1,
+                "VK_KHR_maintenance4": 1,
+                "VK_EXT_texture_compression_astc_hdr": 1,
+                "VK_EXT_inline_uniform_block": 1,
+                "VK_EXT_pipeline_creation_feedback": 1,
+                "VK_EXT_subgroup_size_control": 1,
+                "VK_EXT_tooling_info": 1,
+                "VK_EXT_extended_dynamic_state": 1,
+                "VK_EXT_shader_demote_to_helper_invocation": 1,
+                "VK_EXT_texel_buffer_alignment": 1,
+                "VK_EXT_private_data": 1,
+                "VK_EXT_pipeline_creation_cache_control": 1,
+                "VK_EXT_ycbcr_2plane_444_formats": 1,
+                "VK_EXT_image_robustness": 1,
+                "VK_EXT_extended_dynamic_state2": 1
+            },
+            "features": {
+                "VkPhysicalDeviceVulkan13Features": {
+                    "dynamicRendering": true,
+                    "shaderTerminateInvocation": true,
+                    "shaderIntegerDotProduct": true,
+                    "synchronization2": true,
+                    "shaderZeroInitializeWorkgroupMemory": true,
+                    "maintenance4": true,
+                    "textureCompressionASTC_HDR": true,
+                    "inlineUniformBlock": true,
+                    "descriptorBindingInlineUniformBlockUpdateAfterBind": true,
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true,
+                    "shaderDemoteToHelperInvocation": true,
+                    "privateData": true,
+                    "pipelineCreationCacheControl": true,
+                    "robustImageAccess": true
+                },
+                "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                    "extendedDynamicState": true
+                },
+                "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                    "texelBufferAlignment": true
+                },
+                "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                    "ycbcr2plane444Formats": true
+                },
+                "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                    "extendedDynamicState2": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "vulkanMemoryModelDeviceScope": true
                 }
             }
         }
@@ -171,7 +1437,10 @@
             "capabilities": [
                 "MUST",
                 ["primitivesGeneratedQuery", "pipelineStatisticsQuery"],
-                ["swBresenhamLines", "hwBresenhamLines"]
+                ["swBresenhamLines", "hwBresenhamLines"],
+                "vulkan11pulledrequirements",
+                "vulkan12pulledrequirements",
+                "vulkan13pulledrequirements"
             ]
         }
     }

--- a/profiles/Android/VP_ANDROID_16_requirements.json
+++ b/profiles/Android/VP_ANDROID_16_requirements.json
@@ -3,7 +3,6 @@
     "capabilities": {
         "MUST": {
             "extensions": {
-                "VK_KHR_8bit_storage": 1,
                 "VK_KHR_load_store_op_none": 1,
                 "VK_KHR_maintenance6": 1,
                 "VK_KHR_map_memory2": 1,
@@ -20,19 +19,8 @@
                 "VK_EXT_transform_feedback": 1
             },
             "features": {
-                "VkPhysicalDeviceFeatures": {
-                    "fullDrawIndexUint32": true,
-                    "shaderInt16": true
-                },
-                "VkPhysicalDeviceVulkan12Features": {
-                    "samplerMirrorClampToEdge": true,
-                    "scalarBlockLayout": true
-                },
-                "VkPhysicalDeviceProtectedMemoryFeatures": {
+                "VkPhysicalDeviceVulkan11Features": {
                     "protectedMemory": true
-                },
-                "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                    "shaderIntegerDotProduct": true
                 },
                 "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                     "transformFeedback": true
@@ -42,52 +30,160 @@
                 },
                 "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                     "shaderSubgroupUniformControlFlow": true
+                },
+                "VkPhysicalDeviceMaintenance6FeaturesKHR": {
+                    "maintenance6": true
+                },
+                "VkPhysicalDeviceShaderExpectAssumeFeaturesKHR": {
+                    "shaderExpectAssume": true
+                },
+                "VkPhysicalDeviceShaderFloatControls2FeaturesKHR": {
+                    "shaderFloatControls2": true
+                },
+                "VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR": {
+                    "shaderMaximalReconvergence": true
+                },
+                "VkPhysicalDeviceShaderSubgroupRotateFeaturesKHR": {
+                    "shaderSubgroupRotate": true
+                },
+                "VkPhysicalDeviceHostImageCopyFeaturesEXT": {
+                    "hostImageCopy": true
+                },
+                "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
+                    "pipelineProtectedAccess": true
+                },
+                "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                    "pipelineRobustness": true
                 }
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
                     "limits": {
-                        "bufferImageGranularity": 4096,
-                        "lineWidthGranularity": 0.5,
-                        "maxColorAttachments": 8,
-                        "maxComputeWorkGroupInvocations": 256,
-                        "maxComputeWorkGroupSize": [256, 256, 64],
-                        "maxImageArrayLayers": 2048,
                         "maxImageDimension1D": 8192,
                         "maxImageDimension2D": 8192,
                         "maxImageDimensionCube": 8192,
-                        "maxDescriptorSetStorageBuffers": 96,
-                        "maxDescriptorSetUniformBuffers": 90,
-                        "maxFragmentCombinedOutputResources": 16,
+                        "maxImageArrayLayers": 2048,
+                        "maxUniformBufferRange": 65536,
                         "maxPerStageDescriptorUniformBuffers": 15,
                         "maxPerStageResources": 200,
-                        "maxSamplerLodBias": 14,
-                        "maxUniformBufferRange": 65536,
+                        "maxDescriptorSetUniformBuffers": 90,
+                        "maxDescriptorSetStorageBuffers": 96,
                         "maxVertexOutputComponents": 72,
-                        "mipmapPrecisionBits": 6,
-                        "pointSizeGranularity": 0.125,
-                        "standardSampleLocations": true,
+                        "maxFragmentCombinedOutputResources": 16,
+                        "maxComputeWorkGroupInvocations": 256,
+                        "maxComputeWorkGroupSize": [256, 256, 64],
                         "subTexelPrecisionBits": 8,
+                        "mipmapPrecisionBits": 6,
+                        "maxSamplerLodBias": 14,
+                        "maxColorAttachments": 8,
+                        "pointSizeGranularity": 0.125,
+                        "bufferImageGranularity": 4096,
+                        "lineWidthGranularity": 0.5,
                         "timestampComputeAndGraphics": true
                     }
+                },
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "subgroupSupportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
+                },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "supportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
                 },
                 "VkPhysicalDeviceFloatControlsProperties": {
                     "shaderSignedZeroInfNanPreserveFloat16": true,
                     "shaderSignedZeroInfNanPreserveFloat32": true
                 },
-                "VkPhysicalDeviceVulkan11Properties": {
-                    "subgroupSupportedStages": ["VK_SHADER_STAGE_COMPUTE_BIT"]
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true
+                },
+                "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true
                 }
             }
         },
         "multisampledToSingleSampled": {
             "extensions": {
                 "VK_EXT_multisampled_render_to_single_sampled": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxImageDimension1D": 4096,
+                        "maxImageDimension2D": 4096,
+                        "maxImageDimensionCube": 4096,
+                        "maxImageArrayLayers": 256,
+                        "maxUniformBufferRange": 16384,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageResources": 44,
+                        "maxDescriptorSetUniformBuffers": 36,
+                        "maxDescriptorSetStorageBuffers": 24,
+                        "maxVertexOutputComponents": 64,
+                        "maxFragmentCombinedOutputResources": 8,
+                        "maxComputeWorkGroupInvocations": 128,
+                        "maxComputeWorkGroupSize": [128, 128, 64],
+                        "subTexelPrecisionBits": 4,
+                        "mipmapPrecisionBits": 4,
+                        "maxSamplerLodBias": 2.0,
+                        "maxColorAttachments": 4,
+                        "pointSizeGranularity": 1
+                    }
+                }
             }
         },
         "shaderStencilExport": {
             "extensions": {
                 "VK_EXT_shader_stencil_export": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxImageDimension1D": 4096,
+                        "maxImageDimension2D": 4096,
+                        "maxImageDimensionCube": 4096,
+                        "maxImageArrayLayers": 256,
+                        "maxUniformBufferRange": 16384,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageResources": 44,
+                        "maxDescriptorSetUniformBuffers": 36,
+                        "maxDescriptorSetStorageBuffers": 24,
+                        "maxVertexOutputComponents": 64,
+                        "maxFragmentCombinedOutputResources": 8,
+                        "maxComputeWorkGroupInvocations": 128,
+                        "maxComputeWorkGroupSize": [128, 128, 64],
+                        "subTexelPrecisionBits": 4,
+                        "mipmapPrecisionBits": 4,
+                        "maxSamplerLodBias": 2.0,
+                        "maxColorAttachments": 4,
+                        "pointSizeGranularity": 1
+                    }
+                }
+            }
+        },
+        "vulkan11pulledrequirements": {
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxImageDimension1D": 4096,
+                        "maxImageDimension2D": 4096,
+                        "maxImageDimensionCube": 4096,
+                        "maxImageArrayLayers": 256,
+                        "maxUniformBufferRange": 16384,
+                        "maxPerStageDescriptorUniformBuffers": 12,
+                        "maxPerStageResources": 44,
+                        "maxDescriptorSetUniformBuffers": 36,
+                        "maxDescriptorSetStorageBuffers": 24,
+                        "maxVertexOutputComponents": 64,
+                        "maxFragmentCombinedOutputResources": 8,
+                        "maxComputeWorkGroupInvocations": 128,
+                        "maxComputeWorkGroupSize": [128, 128, 64],
+                        "subTexelPrecisionBits": 4,
+                        "mipmapPrecisionBits": 4,
+                        "maxSamplerLodBias": 2.0,
+                        "maxColorAttachments": 4,
+                        "pointSizeGranularity": 1
+                    }
+                }
             }
         }
     },
@@ -151,7 +247,8 @@
             "profiles": ["VP_ANDROID_15_requirements"],
             "capabilities": [
                 "MUST",
-                ["multisampledToSingleSampled", "shaderStencilExport"]
+                ["multisampledToSingleSampled", "shaderStencilExport"],
+                "vulkan11pulledrequirements"
             ]
         }
     }

--- a/profiles/Android/VP_ANDROID_17_requirements.json
+++ b/profiles/Android/VP_ANDROID_17_requirements.json
@@ -28,6 +28,7 @@
                 "VK_EXT_image_compression_control": 1,
                 "VK_EXT_image_compression_control_swapchain": 1,
                 "VK_EXT_present_mode_fifo_latest_ready": 1,
+                "VK_KHR_calibrated_timestamps": 1,
                 "VK_EXT_present_timing": 1,
                 "VK_EXT_primitive_topology_list_restart": 1,
                 "VK_EXT_provoking_vertex": 1,
@@ -38,37 +39,120 @@
                 "VK_GOOGLE_surfaceless_query": 1
             },
             "features": {
-                "VkPhysicalDevice16BitStorageFeatures": {
-                    "storageInputOutput16": true,
-                    "uniformAndStorageBuffer16BitAccess": true
-                },
-                "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                    "customBorderColors": true
-                },
-                "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
-                    "descriptorBindingVariableDescriptorCount": true
-                },
                 "VkPhysicalDeviceFeatures": {
                     "dualSrcBlend": true,
                     "multiDrawIndirect": true,
                     "shaderInt64": true,
                     "shaderStorageImageWriteWithoutFormat": true
                 },
-                "VkPhysicalDeviceProtectedMemoryFeatures": {
+                "VkPhysicalDeviceVulkan11Features": {
+                    "multiview": true,
+                    "samplerYcbcrConversion": true,
+                    "shaderDrawParameters": true,
+                    "variablePointers": true,
+                    "variablePointersStorageBuffer": true,
+                    "storageBuffer16BitAccess": true,
+                    "storageInputOutput16": true,
+                    "uniformAndStorageBuffer16BitAccess": true,
                     "protectedMemory": true
                 },
-                "VkPhysicalDeviceShaderAtomicInt64Features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true,
+                    "vulkanMemoryModel": true,
+                    "hostQueryReset": true,
+                    "scalarBlockLayout": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "shaderUniformTexelBufferArrayDynamicIndexing": true,
+                    "shaderStorageTexelBufferArrayDynamicIndexing": true,
+                    "shaderSampledImageArrayNonUniformIndexing": true,
+                    "shaderStorageBufferArrayNonUniformIndexing": true,
+                    "shaderUniformTexelBufferArrayNonUniformIndexing": true,
+                    "descriptorBindingSampledImageUpdateAfterBind": true,
+                    "descriptorBindingStorageImageUpdateAfterBind": true,
+                    "descriptorBindingStorageBufferUpdateAfterBind": true,
+                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "runtimeDescriptorArray": true,
                     "shaderBufferInt64Atomics": true
                 },
-                "VkPhysicalDeviceShaderFloat16Int8Features": {
-                    "shaderFloat16": true
-                },
-                "VkPhysicalDeviceVulkan12Features": {
-                    "descriptorBindingVariableDescriptorCount": true,
-                    "shaderFloat16": true
-                },
                 "VkPhysicalDeviceVulkan14Features": {
+                    "indexTypeUint8": true,
                     "hostImageCopy": true
+                },
+                "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                    "customBorderColors": true
+                },
+                "VkPhysicalDeviceMaintenance7FeaturesKHR": {
+                    "maintenance7": true
+                },
+                "VkPhysicalDeviceMaintenance8FeaturesKHR": {
+                    "maintenance8": true
+                },
+                "VkPhysicalDeviceMaintenance9FeaturesKHR": {
+                    "maintenance9": true
+                },
+                "VkPhysicalDevicePipelineBinaryFeaturesKHR": {
+                    "pipelineBinaries": true
+                },
+                "VkPhysicalDevicePresentId2FeaturesKHR": {
+                    "presentId2": true
+                },
+                "VkPhysicalDevicePresentWait2FeaturesKHR": {
+                    "presentWait2": true
+                },
+                "VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR": {
+                    "shaderMaximalReconvergence": true
+                },
+                "VkPhysicalDeviceShaderQuadControlFeaturesKHR": {
+                    "shaderQuadControl": true
+                },
+                "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                    "shaderSubgroupUniformControlFlow": true
+                },
+                "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                    "workgroupMemoryExplicitLayout": true
+                },
+                "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
+                    "reportAddressBinding": true
+                },
+                "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                    "deviceMemoryReport": true
+                },
+                "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                    "graphicsPipelineLibrary": true
+                },
+                "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                    "image2DViewOf3D": true
+                },
+                "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                    "imageCompressionControl": true
+                },
+                "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                    "imageCompressionControlSwapchain": true
+                },
+                "VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR": {
+                    "presentModeFifoLatestReady": true
+                },
+                "VkPhysicalDevicePresentTimingFeaturesEXT": {
+                    "presentTiming": true
+                },
+                "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
+                    "primitiveTopologyListRestart": true
+                },
+                "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                    "provokingVertexLast": true
+                },
+                "VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR": {
+                    "swapchainMaintenance1": true
+                },
+                "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                    "transformFeedback": true
+                },
+                "VkPhysicalDeviceExternalFormatResolveFeaturesANDROID": {
+                    "externalFormatResolve": true
                 }
             },
             "properties": {
@@ -78,14 +162,1207 @@
                     }
                 },
                 "VkPhysicalDeviceVulkan11Properties": {
+                    "maxMultiviewViewCount": 6,
+                    "maxMultiviewInstanceIndex": 134217727,
                     "subgroupSupportedStages": ["VK_SHADER_STAGE_FRAGMENT_BIT"]
+                },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "supportedStages": ["VK_SHADER_STAGE_FRAGMENT_BIT"]
                 }
             },
             "formats": {
+                "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_B8G8R8A8_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_D16_UNORM": {
+                    "VkFormatProperties3": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_D32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16A16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16B16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16G16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R16_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32A32_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32B32_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32G32_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R32_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8A8_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8B8_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8G8_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_SRGB": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UINT": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_R8_UNORM": {
+                    "VkFormatProperties3": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "bufferFeatures": ["VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT", "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT"],
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT", "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
+                "VK_FORMAT_S8_UINT": {
+                    "VkFormatProperties3": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    },
+                    "VkFormatProperties3KHR": {
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"]
+                    }
+                },
                 "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
                     }
                 },
@@ -93,6 +1370,16 @@
                     "VkFormatProperties": {
                         "linearTilingFeatures": ["VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
                         "optimalTilingFeatures": ["VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_BLIT_DST_BIT", "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "bufferFeatures": []
+                    },
+                    "VkFormatProperties3KHR": {
+                        "linearTilingFeatures": ["VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
+                        "optimalTilingFeatures": ["VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT", "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT", "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT", "VK_FORMAT_FEATURE_2_BLIT_DST_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT", "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"],
                         "bufferFeatures": []
                     }
                 }
@@ -102,9 +1389,11 @@
             "extensions": {
                 "VK_EXT_primitives_generated_query": 1
             },
-            "features": {
-                "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                    "primitivesGeneratedQuery": true
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 126
+                    }
                 }
             }
         },
@@ -113,16 +1402,192 @@
                 "VkPhysicalDeviceFeatures": {
                     "pipelineStatisticsQuery": true
                 }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 126
+                    }
+                }
             }
         },
         "multisampledToSingleSampled": {
             "extensions": {
                 "VK_EXT_multisampled_render_to_single_sampled": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 126
+                    }
+                }
             }
         },
         "shaderStencilExport": {
             "extensions": {
                 "VK_EXT_shader_stencil_export": 1
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 126
+                    }
+                }
+            }
+        },
+        "vulkan11pulledrequirements": {
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "limits": {
+                        "maxDescriptorSetStorageImages": 126
+                    }
+                }
+            }
+        },
+        "vulkan12pulledrequirements": {
+            "extensions": {
+                "VK_KHR_imageless_framebuffer": 1,
+                "VK_KHR_draw_indirect_count": 1,
+                "VK_KHR_shader_subgroup_extended_types": 1,
+                "VK_KHR_8bit_storage": 1,
+                "VK_KHR_shader_atomic_int64": 1,
+                "VK_KHR_depth_stencil_resolve": 1,
+                "VK_KHR_timeline_semaphore": 1,
+                "VK_KHR_spirv_1_4": 1,
+                "VK_KHR_separate_depth_stencil_layouts": 1,
+                "VK_KHR_uniform_buffer_standard_layout": 1,
+                "VK_KHR_buffer_device_address": 1,
+                "VK_EXT_sampler_filter_minmax": 1,
+                "VK_EXT_shader_viewport_index_layer": 1
+            },
+            "features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "imagelessFramebuffer": true,
+                    "shaderSubgroupExtendedTypes": true,
+                    "storageBuffer8BitAccess": true,
+                    "timelineSemaphore": true,
+                    "separateDepthStencilLayouts": true,
+                    "uniformBufferStandardLayout": true,
+                    "bufferDeviceAddress": true,
+                    "subgroupBroadcastDynamicId": true,
+                    "samplerMirrorClampToEdge": true,
+                    "drawIndirectCount": true,
+                    "descriptorIndexing": true,
+                    "shaderOutputViewportIndex": true,
+                    "shaderOutputLayer": true,
+                    "samplerFilterMinmax": true
+                }
+            }
+        },
+        "vulkan13pulledrequirements": {
+            "extensions": {
+                "VK_KHR_dynamic_rendering": 1,
+                "VK_KHR_shader_terminate_invocation": 1,
+                "VK_KHR_shader_integer_dot_product": 1,
+                "VK_KHR_shader_non_semantic_info": 1,
+                "VK_KHR_synchronization2": 1,
+                "VK_KHR_zero_initialize_workgroup_memory": 1,
+                "VK_KHR_copy_commands2": 1,
+                "VK_KHR_format_feature_flags2": 1,
+                "VK_KHR_maintenance4": 1,
+                "VK_EXT_texture_compression_astc_hdr": 1,
+                "VK_EXT_inline_uniform_block": 1,
+                "VK_EXT_pipeline_creation_feedback": 1,
+                "VK_EXT_subgroup_size_control": 1,
+                "VK_EXT_tooling_info": 1,
+                "VK_EXT_extended_dynamic_state": 1,
+                "VK_EXT_shader_demote_to_helper_invocation": 1,
+                "VK_EXT_texel_buffer_alignment": 1,
+                "VK_EXT_private_data": 1,
+                "VK_EXT_pipeline_creation_cache_control": 1,
+                "VK_EXT_ycbcr_2plane_444_formats": 1,
+                "VK_EXT_image_robustness": 1,
+                "VK_EXT_4444_formats": 1,
+                "VK_EXT_extended_dynamic_state2": 1
+            },
+            "features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "vulkanMemoryModelDeviceScope": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+                    "dynamicRendering": true,
+                    "shaderTerminateInvocation": true,
+                    "shaderIntegerDotProduct": true,
+                    "synchronization2": true,
+                    "shaderZeroInitializeWorkgroupMemory": true,
+                    "maintenance4": true,
+                    "textureCompressionASTC_HDR": true,
+                    "inlineUniformBlock": true,
+                    "descriptorBindingInlineUniformBlockUpdateAfterBind": true,
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true,
+                    "shaderDemoteToHelperInvocation": true,
+                    "privateData": true,
+                    "pipelineCreationCacheControl": true,
+                    "robustImageAccess": true
+                },
+                "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                    "extendedDynamicState": true
+                },
+                "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                    "texelBufferAlignment": true
+                },
+                "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                    "ycbcr2plane444Formats": true
+                },
+                "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                    "formatA4R4G4B4": true
+                },
+                "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                    "extendedDynamicState2": true
+                }
+            }
+        },
+        "vulkan14pulledrequirements": {
+            "extensions": {
+                "VK_KHR_push_descriptor": 1,
+                "VK_KHR_global_priority": 1,
+                "VK_KHR_dynamic_rendering_local_read": 1,
+                "VK_KHR_map_memory2": 1,
+                "VK_KHR_shader_subgroup_rotate": 1,
+                "VK_KHR_maintenance5": 1,
+                "VK_KHR_vertex_attribute_divisor": 1,
+                "VK_KHR_load_store_op_none": 1,
+                "VK_KHR_shader_float_controls2": 1,
+                "VK_KHR_index_type_uint8": 1,
+                "VK_KHR_line_rasterization": 1,
+                "VK_KHR_shader_expect_assume": 1,
+                "VK_KHR_maintenance6": 1,
+                "VK_EXT_pipeline_robustness": 1,
+                "VK_EXT_host_image_copy": 1,
+                "VK_EXT_pipeline_protected_access": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "depthClamp": true,
+                    "samplerAnisotropy": true,
+                    "shaderImageGatherExtended": true
+                },
+                "VkPhysicalDeviceVulkan14Features": {
+                    "globalPriorityQuery": true,
+                    "dynamicRenderingLocalRead": true,
+                    "shaderSubgroupRotate": true,
+                    "maintenance5": true,
+                    "vertexAttributeInstanceRateDivisor": true,
+                    "shaderFloatControls2": true,
+                    "rectangularLines": true,
+                    "bresenhamLines": true,
+                    "smoothLines": true,
+                    "stippledRectangularLines": true,
+                    "stippledBresenhamLines": true,
+                    "stippledSmoothLines": true,
+                    "shaderExpectAssume": true,
+                    "maintenance6": true,
+                    "pipelineRobustness": true,
+                    "pipelineProtectedAccess": true,
+                    "shaderSubgroupRotateClustered": true,
+                    "pushDescriptor": true
+                }
             }
         }
     },
@@ -183,7 +1648,11 @@
             "capabilities": [
                 "MUST",
                 ["primitivesGeneratedQuery", "pipelineStatisticsQuery"],
-                ["multisampledToSingleSampled", "shaderStencilExport"]
+                ["multisampledToSingleSampled", "shaderStencilExport"],
+                "vulkan11pulledrequirements",
+                "vulkan12pulledrequirements",
+                "vulkan13pulledrequirements",
+                "vulkan14pulledrequirements"
             ],
             "profiles": ["VP_ANDROID_vulkan_profile_2025"]
         }

--- a/profiles/Android/VP_ANDROID_vulkan_profile_2021.json
+++ b/profiles/Android/VP_ANDROID_vulkan_profile_2021.json
@@ -40,6 +40,12 @@
                     "shaderUniformBufferArrayDynamicIndexing": true,
                     "textureCompressionASTC_LDR": true,
                     "textureCompressionETC2": true
+                },
+                "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                    "variablePointersStorageBuffer": true
+                },
+                "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                    "variablePointersStorageBuffer": true
                 }
             },
             "properties": {

--- a/profiles/Android/VP_ANDROID_vulkan_profile_2022.json
+++ b/profiles/Android/VP_ANDROID_vulkan_profile_2022.json
@@ -25,8 +25,8 @@
                 "VK_KHR_external_fence": 1,
                 "VK_KHR_external_fence_fd": 1,
                 "VK_KHR_variable_pointers": 1,
-                "VK_ANDROID_external_memory_android_hardware_buffer": 1,
                 "VK_EXT_queue_family_foreign": 1,
+                "VK_ANDROID_external_memory_android_hardware_buffer": 1,
                 "VK_KHR_driver_properties": 1,
                 "VK_KHR_create_renderpass2": 1,
                 "VK_KHR_sampler_mirror_clamp_to_edge": 1
@@ -144,6 +144,10 @@
                     }
                 },
                 "VkPhysicalDeviceMultiviewProperties": {
+                    "maxMultiviewInstanceIndex": 134217727,
+                    "maxMultiviewViewCount": 6
+                },
+                "VkPhysicalDeviceMultiviewPropertiesKHR": {
                     "maxMultiviewInstanceIndex": 134217727,
                     "maxMultiviewViewCount": 6
                 }
@@ -773,6 +777,25 @@
                     }
                 }
             }
+        },
+        "vulkan11pulledrequirements": {
+            "extensions": {
+                "VK_KHR_multiview": 1,
+                "VK_KHR_device_group_creation": 1,
+                "VK_KHR_device_group": 1,
+                "VK_KHR_shader_draw_parameters": 1,
+                "VK_KHR_16bit_storage": 1,
+                "VK_KHR_maintenance2": 1,
+                "VK_KHR_relaxed_block_layout": 1,
+                "VK_KHR_sampler_ycbcr_conversion": 1,
+                "VK_KHR_bind_memory2": 1,
+                "VK_KHR_maintenance3": 1
+            },
+            "features": {
+                "VkPhysicalDevice16BitStorageFeatures": {
+                    "storageBuffer16BitAccess": true
+                }
+            }
         }
     },
     "profiles": {
@@ -813,7 +836,7 @@
                     "comment": "Renamed/rebranded from 'VP_ANDROID_baseline_2022' (a.k.a. Android Baseline Profile 2022 or ABP 2022) to 'VP_ANDROID_vulkan_profile_2022' (a.k.a. Android Vulkan Profile 2022 or AVP 2022)"
                 }
             ],
-            "capabilities": ["baseline"]
+            "capabilities": ["baseline", "vulkan11pulledrequirements"]
         }
     }
 }

--- a/profiles/Android/VP_ANDROID_vulkan_profile_2025.json
+++ b/profiles/Android/VP_ANDROID_vulkan_profile_2025.json
@@ -3,27 +3,29 @@
     "capabilities": {
         "baseline": {
             "extensions": {
+                "VK_KHR_surface": 1,
                 "VK_KHR_android_surface": 1,
                 "VK_KHR_bind_memory2": 1,
                 "VK_KHR_create_renderpass2": 1,
                 "VK_KHR_dedicated_allocation": 1,
                 "VK_KHR_descriptor_update_template": 1,
-                "VK_KHR_device_group": 1,
                 "VK_KHR_device_group_creation": 1,
+                "VK_KHR_device_group": 1,
                 "VK_KHR_driver_properties": 1,
-                "VK_KHR_external_fence": 1,
                 "VK_KHR_external_fence_capabilities": 1,
+                "VK_KHR_external_fence": 1,
                 "VK_KHR_external_fence_fd": 1,
                 "VK_KHR_external_memory": 1,
                 "VK_KHR_external_memory_capabilities": 1,
                 "VK_KHR_external_memory_fd": 1,
-                "VK_KHR_external_semaphore": 1,
                 "VK_KHR_external_semaphore_capabilities": 1,
+                "VK_KHR_external_semaphore": 1,
                 "VK_KHR_external_semaphore_fd": 1,
                 "VK_KHR_get_memory_requirements2": 1,
                 "VK_KHR_get_physical_device_properties2": 1,
                 "VK_KHR_get_surface_capabilities2": 1,
                 "VK_KHR_image_format_list": 1,
+                "VK_KHR_swapchain": 1,
                 "VK_KHR_incremental_present": 1,
                 "VK_KHR_maintenance1": 1,
                 "VK_KHR_maintenance2": 1,
@@ -36,16 +38,14 @@
                 "VK_KHR_shader_float16_int8": 1,
                 "VK_KHR_shader_float_controls": 1,
                 "VK_KHR_storage_buffer_storage_class": 1,
-                "VK_KHR_surface": 1,
-                "VK_KHR_swapchain": 1,
                 "VK_KHR_variable_pointers": 1,
                 "VK_KHR_vulkan_memory_model": 1,
+                "VK_EXT_queue_family_foreign": 1,
                 "VK_ANDROID_external_memory_android_hardware_buffer": 1,
                 "VK_GOOGLE_display_timing": 1,
                 "VK_EXT_debug_report": 1,
                 "VK_EXT_host_query_reset": 1,
                 "VK_EXT_index_type_uint8": 1,
-                "VK_EXT_queue_family_foreign": 1,
                 "VK_EXT_scalar_block_layout": 1,
                 "VK_EXT_separate_stencil_usage": 1,
                 "VK_EXT_swapchain_colorspace": 1
@@ -78,16 +78,35 @@
                 "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                     "samplerYcbcrConversion": true
                 },
-                "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                "VkPhysicalDeviceShaderDrawParametersFeatures": {
                     "shaderDrawParameters": true
                 },
-                "VkPhysicalDeviceVariablePointerFeatures": {
+                "VkPhysicalDeviceVariablePointersFeatures": {
                     "variablePointers": true,
                     "variablePointersStorageBuffer": true
                 },
-                "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                    "variablePointers": true,
-                    "variablePointersStorageBuffer": true
+                "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true
+                },
+                "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true
+                },
+                "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                    "vulkanMemoryModel": true
+                },
+                "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                    "hostQueryReset": true
+                },
+                "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                    "indexTypeUint8": true
+                },
+                "VkPhysicalDeviceIndexTypeUint8FeaturesKHR": {
+                    "indexTypeUint8": true
+                },
+                "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                    "scalarBlockLayout": true
                 }
             },
             "properties": {
@@ -170,6 +189,10 @@
                     }
                 },
                 "VkPhysicalDeviceMultiviewProperties": {
+                    "maxMultiviewViewCount": 6,
+                    "maxMultiviewInstanceIndex": 134217727
+                },
+                "VkPhysicalDeviceMultiviewPropertiesKHR": {
                     "maxMultiviewViewCount": 6,
                     "maxMultiviewInstanceIndex": 134217727
                 }
@@ -876,6 +899,16 @@
                     }
                 }
             }
+        },
+        "vulkan11pulledrequirements": {
+            "extensions": {
+                "VK_KHR_16bit_storage": 1
+            },
+            "features": {
+                "VkPhysicalDevice16BitStorageFeatures": {
+                    "storageBuffer16BitAccess": true
+                }
+            }
         }
     },
     "profiles": {
@@ -910,7 +943,7 @@
                     "comment": "Updated the profile based on partner feedbacks"
                 }
             ],
-            "capabilities": ["baseline"]
+            "capabilities": ["baseline", "vulkan11pulledrequirements"]
         }
     }
 }


### PR DESCRIPTION
Generated using the command:

```
vkprofiles convert 
      --registry E:\\Github\\khronos\\Vulkan-Profiles\\external\\Debug\\64\\Vulkan-Headers\\registry\\vk.xml
      --input E:\\Github\\khronos\\Vulkan-Profiles\\profiles\\Android
      --output E:\\Github\\khronos\\Vulkan-Profiles\\build\\profiles
      --mode pull-extension-dependencies pull-promoted-extensions ignore-extension-versions pull-required-capabilities  pull-aliases strip-duplication
```

`vkprofiles convert` tasks: 
- Searching for extensions, features and properties that are duplicated and previously set in previous capabilities blocks or profiles.
- Filling the gaps of capabilities that have multiple ways to be declared. The profiles sometime declares the capability in Vulkan1X structure, sometime in the split structure. After the script is processed, the declares them everywhere.
- Pulling the extensions and features that are required by Vulkan extensions and features.
- Pull required features from Vulkan versions.

Todo:
- Add pulling of Vulkan properties and foramts requirements
